### PR TITLE
Port the withRetries functionality into quiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@ Change Log
 Version 1.0.0 *(2023-03-06)*
 ----------------------------
 
-* Add Option.unit() and Either.unit() to replace the void() method deprecated by Arrow.
+* Add `Option.unit()` and `Either.unit()` to replace the `void()` method deprecated by Arrow.
+* Include `withRetries` method on suspended supplier functions to provide opinionated access to Arrow's `Schedule`.

--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ Turns the `Option` into a `Validated` list of `T` if it's a `Some`. If it's a `N
 
 The outcome of a suspended function is mapped into a second suspended fuction, as if the function were a functor.
 
+#### withRetries
+
+Allows suspended supplier functions to be retried until success or exhaustion.
+
 ### Validated
 
 #### ValidatedNel.attemptValidated

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ versionsGradlePlugin = "0.46.0"
 
 [libraries]
 arrowCore = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
+arrowFxCoroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrow" }
 junitApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 kotestAssertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -162,6 +162,7 @@ public final class app/cash/quiver/extensions/EitherKt {
 	public static final fun orThrow (Larrow/core/Either;)Ljava/lang/Object;
 	public static final fun tapLeft (Larrow/core/Either;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toEither (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Larrow/core/Either;
+	public static final fun unit (Larrow/core/Either;)Larrow/core/Either;
 }
 
 public final class app/cash/quiver/extensions/ListKt {
@@ -182,11 +183,14 @@ public final class app/cash/quiver/extensions/OptionKt {
 	public static final fun forEach (Larrow/core/Option;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun ifAbsent (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)V
 	public static final fun toValidatedNel (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Larrow/core/Validated;
+	public static final fun unit (Larrow/core/Option;)Larrow/core/Option;
 }
 
 public final class app/cash/quiver/extensions/SuspendedFunctionKt {
 	public static final fun map (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public static final fun map (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function2;
+	public static final fun withRetries (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/time/Duration;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun withRetries$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/time/Duration;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class app/cash/quiver/extensions/ValidatedKt {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
   implementation(kotlin("reflect"))
   implementation(libs.arrowCore)
+  implementation(libs.arrowFxCoroutines)
 
   testImplementation(project(":testing-lib"))
   testImplementation(libs.junitApi)

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/SuspendedFunction.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/SuspendedFunction.kt
@@ -1,9 +1,47 @@
 package app.cash.quiver.extensions
 
+import arrow.core.Either
+import arrow.fx.coroutines.Schedule
+import java.time.Duration
+
+/**
+ * Map on this suspended supplier with a suspended function.
+ */
 fun <A, B> (suspend () -> A).map(f: (A) -> B): suspend () -> B = suspend {
   f(this.invoke())
 }
 
+/**
+ * Map on this suspended function with another.
+ */
 fun <A, B, C> (suspend (A) -> B).map(f: (B) -> C): suspend (A) -> C = { a: A ->
   f(this.invoke(a))
+}
+
+/**
+ * Retry a suspended supplier until a maximum number of times or a predicate has been fulfilled.
+ *
+ * @param until the predicate that indicates success. Defaults to "no exceptions encountered".
+ * @param additionalTimes how many times to retry before giving up. Defaults to 4 (5 attempts in total).
+ * @param delay how long to delay between attempts. Defaults to 20ms.
+ * @param exponentialBackoff if true, will double the delay on each attempt. Defaults to false.
+ * @param jitter if true, will stagger the attempts to reduce likelihood of collisions. Defaults to false.
+ */
+suspend fun <T> (suspend () -> T).withRetries(
+  until: (ErrorOr<T>) -> Boolean = { it.isRight() },
+  additionalTimes: Int = 4,
+  delay: Duration = Duration.ofMillis(20L),
+  exponentialBackoff: Boolean = false,
+  jitter: Boolean = false,
+): ErrorOr<T> {
+  val baseSchedule =
+    if (exponentialBackoff) Schedule.exponential(delay.toNanos().toDouble())
+    else Schedule.spaced<ErrorOr<T>>(delay.toNanos().toDouble())
+  val schedule = baseSchedule
+    .untilInput<ErrorOr<T>> { until(it) }
+    .and(Schedule.recurs(additionalTimes))
+    .zipRight(Schedule.identity()).let {
+      if (jitter) it.jittered() else it
+    }
+  return schedule.repeat { Either.catch { invoke() } }
 }

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/EffectTester.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/EffectTester.kt
@@ -1,0 +1,36 @@
+package app.cash.quiver.extensions
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class EffectTester<T> {
+  private lateinit var effectResults: List<suspend () -> T>
+  private val effectCallCount = AtomicInteger(0)
+  private val effectIndex = AtomicInteger(0)
+
+  /**
+   * Each time the effect is invoked, it will return the given result.
+   */
+  constructor(effectResult: T) {
+    this.effectResults = listOf { effectResult }
+  }
+
+  /**
+   * Each time the effect is invoked, the next result in the list will be provided. When the list is exhausted, it will
+   * wrap to the beginning again to provide an infinite sequence.
+   */
+  constructor(effectResults: List<suspend () -> T>) {
+    this.effectResults = effectResults
+  }
+
+  /**
+   * Each time the effect is invoked, it will return the given result.
+   */
+  val effect: suspend () -> T = {
+    effectCallCount.incrementAndGet()
+    // Index the next element in the list and increments the pointer. Will wrap to 0 at the end of the list.
+    val result = effectResults[effectIndex.getAndUpdate { (it + 1) % effectResults.size }]()
+    result
+  }
+
+  fun callCount() = effectCallCount.get()
+}

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/RetryTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/RetryTest.kt
@@ -1,0 +1,82 @@
+package app.cash.quiver.extensions
+
+import arrow.core.getOrElse
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+
+class RetryTest : StringSpec({
+
+  val runtimeException = RuntimeException("bad")
+
+  "no retries when the effect is successful" {
+    val effectTester = EffectTester(true)
+    val result = effectTester.effect.withRetries(until = { it.isRight() })
+    result shouldBeRight true
+    effectTester.callCount() shouldBe 1
+  }
+
+  "default until function should check the right side of the either when retrying" {
+    val effectTester = EffectTester(true)
+    val result = effectTester.effect.withRetries()
+    result shouldBeRight true
+    effectTester.callCount() shouldBe 1
+  }
+
+  "one retry when the first call is unsuccessful" {
+    val effectTester = EffectTester(listOf(false, true, true).map { { it } })
+    val result = effectTester.effect.withRetries(
+      until = { it.getOrElse { false } },
+      delay = Duration.ofMillis(1L)
+    )
+    result shouldBeRight true
+    effectTester.callCount() shouldBe 2
+  }
+
+  "exhaust retrying when no call is successful" {
+    val effectTester = EffectTester(false)
+    val result = effectTester.effect.withRetries(
+      until = { it.getOrElse { false } },
+      additionalTimes = 7,
+      delay = Duration.ofMillis(1L)
+    )
+    result shouldBeRight false
+    effectTester.callCount() shouldBe 8
+  }
+
+  "retry on error until success" {
+    val effectTester = EffectTester(listOf({ throw runtimeException }, { true }))
+    val result = effectTester.effect.withRetries(
+      until = { it.isRight() },
+      delay = Duration.ofMillis(1)
+    ).orThrow()
+    result shouldBe true
+    effectTester.callCount() shouldBe 2
+  }
+
+  "retry on error until exhausted" {
+    val effectTester = EffectTester<Boolean>(listOf { throw runtimeException })
+    shouldThrow<RuntimeException> {
+      effectTester.effect.withRetries(
+        until = { it.isRight() },
+        additionalTimes = 3,
+        delay = Duration.ofMillis(1)
+      ).orThrow()
+    }
+    effectTester.callCount() shouldBe 4
+  }
+
+  "be able to ignore expected errors when retrying" {
+    val effectTester = EffectTester<Boolean>(listOf { throw runtimeException })
+    shouldThrow<RuntimeException> {
+      effectTester.effect.withRetries(
+        until = { it.isLeft() },
+        delay = Duration.ofMillis(1)
+      ).orThrow()
+    }
+    effectTester.callCount() shouldBe 1
+  }
+
+})


### PR DESCRIPTION
This is simplified from the original.
It will always return ErrorOr
and the options around whether it is "polling" or not are made more explicit in the method parameters (`jitter` and `backoff`)