### PR TITLE
Adds validateNotNull extension function on nullable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ Like `forEach`, but left-biased.
 
 Performs an effect over the right side of the value but maps the original value back into the Either. This is useful for mixing with validation functions.
 
+#### validateNotNull
+
+Turns a nullable value into an Either:
+- Left if the value is null.
+- Right if the value is not null.
+
+Useful for building validation functions.
+
 ### Lists
 
 #### filterNotNone

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -163,6 +163,8 @@ public final class app/cash/quiver/extensions/EitherKt {
 	public static final fun tapLeft (Larrow/core/Either;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toEither (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Larrow/core/Either;
 	public static final fun unit (Larrow/core/Either;)Larrow/core/Either;
+	public static final fun validateNotNull (Ljava/lang/Object;Larrow/core/Option;)Larrow/core/Either;
+	public static synthetic fun validateNotNull$default (Ljava/lang/Object;Larrow/core/Option;ILjava/lang/Object;)Larrow/core/Either;
 }
 
 public final class app/cash/quiver/extensions/ListKt {

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
@@ -14,6 +14,16 @@ import arrow.core.toOption
 fun <A> Either<Throwable, A>.orThrow() = this.getOrElse { t -> throw t }
 
 /**
+ * Turns a nullable value into an [Either]. This is useful for building validation functions.
+ *
+ * @return [Either.Left] if the value is null, [Either.Right] if the value is not null.
+ * @param label Optional [String] to identify the nullable value being evaluated, used in the failure message.
+ */
+fun <B> B?.validateNotNull(label: Option<String> = None): Either<Throwable, B> = this.toEither {
+  IllegalArgumentException("Value${label.map { " (`$it`)" }.getOrElse { "" }} should not be null")
+}
+
+/**
  * Returns the first successful either, otherwise the last failure
  */
 inline fun <E, A> Either<E, A>.or(f: () -> Either<E, A>): Either<E, A> = when (this) {

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/EitherTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/EitherTest.kt
@@ -6,6 +6,7 @@ import arrow.core.Option
 import arrow.core.Some
 import arrow.core.left
 import arrow.core.right
+import arrow.core.some
 import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.assertions.arrow.core.shouldBeSome
@@ -65,6 +66,21 @@ class EitherTest : StringSpec({
   "unit will map any right to unit" {
     "orange".right().unit() shouldBe Unit.right()
     "orange".left().unit() shouldBe "orange".left()
+  }
+
+  "validateNotNull is right if value is not null" {
+    val value = "test"
+    value.validateNotNull().shouldBeRight()
+  }
+
+  "validateNotNull is left if value is null" {
+    val value: String? = null
+    value.validateNotNull().shouldBeLeft(IllegalArgumentException("Value should not be null"))
+  }
+
+  "validateNotNull is left if value is null - with label" {
+    val value: String? = null
+    value.validateNotNull("label".some()).shouldBeLeft(IllegalArgumentException("Value (`label`) should not be null"))
   }
 })
 


### PR DESCRIPTION
This extension function makes it easy to lift a nullable value into an Either.

Example usage:
```kt
// Incoming request with nullable values
data class Request(
  val foo: String?,
  val bar: Int?
)

// Internal data structure using non-nullable values
data class ValidatedRequest(
  val foo: String,
  val bar: Int
)

// Converts a request with nullable values into a ValidatedRequest
fun validate(request: Request) = either.eager {
  ValidatedRequest(
    foo = request.foo.validateNotNull().bind(),
    bar = request.bar.validateNotNull().bind()
  )
}
```