### PR TITLE
Fix nested null bug

### DIFF
--- a/lib/src/main/kotlin/app/cash/quiver/extensions/List.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/List.kt
@@ -1,11 +1,12 @@
 package app.cash.quiver.extensions
 
 import arrow.core.Option
+import arrow.core.filterOption
 
 /**
  * Returns a list without Nones
  */
-fun <A> List<Option<A>>.filterNotNone(): List<A> = this.mapNotNull { it.orNull() }
+fun <A> List<Option<A>>.filterNotNone(): List<A> = filterOption()
 
 /**
  * Constructs a flattened list without Nones
@@ -17,4 +18,4 @@ fun <A> listOfSome(vararg elements: Option<A>): List<A> = elements.toList().filt
  * to each element in the original collection.
  */
 inline fun <A, B> List<A>.mapNotNone(f: (A) -> Option<B>): List<B> =
-  this.mapNotNull { f(it).orNull() }
+  this.flatMap { f(it).fold(::emptyList, ::listOf) }

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.shouldBe
 class OptionTest : StringSpec({
 
   "can construct a list of only the somes" {
-    listOfSome("a".some(), None, "c".some()) shouldBe listOf("a", "c")
+    listOfSome("a".some(), None, null.some()) shouldBe listOf("a", null)
   }
 
   "unit will map any some to unit" {


### PR DESCRIPTION
Hey all 👋
Very exciting to see this initiative 🙌 Glad to see you're using, and hopefully enjoying Arrow.

This PR fixes an issue of nested generic null, which is typically why you'd want to use `Option`. If `A` is not constrained to `Any`, `A : Any`, then a _nested null_ can occur. Relying on `mapNotNull + orNull` filters out the  _nested null_. I updated the test to reflect the issue.

(I could not build the project locally due to missing `./gradlew` and some CashApp specific build settings) but I didn't really investigate it much.

I saw you were re-adding some APIs that we've deprecated, and introduced some new methods. I think these `Option` based methods could also be merged upstream into Arrow. Although I am also excited that there is a library introducing new types like `Outcome`, and integrating with the DSL.

Soon we're releasing `1.2.0`, and if you'd want I'd be happy to create a PR updating to the new code ☺️ I'm also working on a [OpenRewrite](https://docs.openrewrite.org) automated migration tool [rewrite-arrow](https://github.com/nomisRev/rewrite-arrow) that should take of it automatically as well.

Looking forward to your feedback, and thank you all for open-sourcing this library 👏 🥳 