### PR TITLE
Fix Map.getOption nested null bug

### DIFF
--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Map.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Map.kt
@@ -1,8 +1,12 @@
 package app.cash.quiver.extensions
 
+import arrow.core.None
 import arrow.core.Option
+import arrow.core.Some
 
 /**
  * Extension function to get an Option from a nullable object on a map.
  */
-fun <K, A> Map<K, A>.getOption(k: K): Option<A> = Option.fromNullable(this[k])
+@Suppress("UNCHECKED_CAST")
+fun <K, A> Map<K, A>.getOption(k: K): Option<A> =
+  if (containsKey(k)) Some(get(k) as A) else None

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/MapTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/MapTest.kt
@@ -1,0 +1,14 @@
+package app.cash.quiver.extensions
+
+import arrow.core.Some
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class MapTest : StringSpec({
+  "Can retrieve null value key" {
+    mapOf(
+      "one" to 1,
+      "null" to null
+    ).getOption("null") shouldBe Some(null)
+  }
+})


### PR DESCRIPTION
This PR fixes a bug with _nested null_, or when `V` is `null`, in `Map.getOption`.