### PR TITLE
Use inline where possible

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -154,13 +154,13 @@ public final class app/cash/quiver/continuations/outcome {
 public final class app/cash/quiver/extensions/EitherKt {
 	public static final fun asOption (Larrow/core/Either;)Larrow/core/Option;
 	public static final fun flatTap (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
-	public static final fun forEach (Larrow/core/Either;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun forEach (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)V
 	public static final fun leftAsOption (Larrow/core/Either;)Larrow/core/Option;
-	public static final fun leftForEach (Larrow/core/Either;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun leftForEach (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)V
 	public static final fun mapOption (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun or (Larrow/core/Either;Lkotlin/jvm/functions/Function0;)Larrow/core/Either;
 	public static final fun orThrow (Larrow/core/Either;)Ljava/lang/Object;
-	public static final fun tapLeft (Larrow/core/Either;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun tapLeft (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun toEither (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Larrow/core/Either;
 	public static final fun unit (Larrow/core/Either;)Larrow/core/Either;
 	public static final fun validateNotNull (Ljava/lang/Object;Larrow/core/Option;)Larrow/core/Either;
@@ -182,7 +182,7 @@ public final class app/cash/quiver/extensions/NonEmptyListKt {
 }
 
 public final class app/cash/quiver/extensions/OptionKt {
-	public static final fun forEach (Larrow/core/Option;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun forEach (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)V
 	public static final fun ifAbsent (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)V
 	public static final fun toValidatedNel (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Larrow/core/Validated;
 	public static final fun unit (Larrow/core/Option;)Larrow/core/Option;

--- a/lib/src/main/kotlin/app/cash/quiver/Outcome.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/Outcome.kt
@@ -40,13 +40,13 @@ sealed class Outcome<out E, out A> constructor(val inner: Either<E, Option<A>>) 
      * Catches any exceptions thrown by the function and lifts the result into an Outcome.  If your function
      * returns an option use `catchOption` instead
      */
-    fun <R> catch(f: () -> R): Outcome<Throwable, R> = Either.catch(f).map(::Some).toOutcome()
+    inline fun <R> catch(f: () -> R): Outcome<Throwable, R> = Either.catch(f).map(::Some).toOutcome()
 
     /**
      * Catches any exceptions thrown by the function and lifts the result into an Outcome.  The Optional
      * value will be preserved as Present or Absent accordingly.
      */
-    fun <R> catchOption(f: () -> Option<R>): Outcome<Throwable, R> = Either.catch(f).toOutcome()
+    inline fun <R> catchOption(f: () -> Option<R>): Outcome<Throwable, R> = Either.catch(f).toOutcome()
   }
 }
 
@@ -124,7 +124,7 @@ fun <E, A> Either<E, A>.asOutcome(): Outcome<E, A> = this.map(::Some).toOutcome(
 
 fun <A> Option<A>.toOutcome(): Outcome<Nothing, A> = this.right().toOutcome()
 
-fun <A> Outcome<Throwable, A>.orThrow(onAbsent: () -> Throwable): A = when (this) {
+inline fun <A> Outcome<Throwable, A>.orThrow(onAbsent: () -> Throwable): A = when (this) {
   Absent -> throw onAbsent()
   is Failure -> throw this.error
   is Present -> this.value
@@ -199,11 +199,11 @@ fun <E, A> Iterable<Outcome<E, A>>.sequence(): Outcome<E, List<A>> = this.fold(P
   acc.zip(e) { a1, a2 -> a1 + a2 }
 }
 
-fun <E, A, B> Outcome<E, A>.traverse(f: (A) -> List<B>): List<Outcome<E, B>> = this.map(f).sequence()
-fun <E, A, B> Outcome<E, A>.traverse(f: (A) -> Option<B>): Option<Outcome<E, B>> = this.map(f).sequence()
+inline fun <E, A, B> Outcome<E, A>.traverse(f: (A) -> List<B>): List<Outcome<E, B>> = this.map(f).sequence()
+inline fun <E, A, B> Outcome<E, A>.traverse(f: (A) -> Option<B>): Option<Outcome<E, B>> = this.map(f).sequence()
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-fun <E, EE, A, B> Outcome<E, A>.traverse(f: (A) -> Either<EE, B>): Either<EE, Outcome<E, B>> = this.map(f).sequence()
-fun <E, EE, A, B> Outcome<E, A>.traverse(f: (A) -> Validated<EE, B>): Validated<EE, Outcome<E, B>> =
+inline fun <E, EE, A, B> Outcome<E, A>.traverse(f: (A) -> Either<EE, B>): Either<EE, Outcome<E, B>> = this.map(f).sequence()
+inline fun <E, EE, A, B> Outcome<E, A>.traverse(f: (A) -> Validated<EE, B>): Validated<EE, Outcome<E, B>> =
   this.map(f).sequence()

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
@@ -50,7 +50,8 @@ fun <E, A> Either<E, A>.leftAsOption(): Option<E> = when (this) {
 /**
  * Pass the left value to the function (e.g. for logging errors)
  */
-suspend fun <A, B> Either<A, B>.tapLeft(f: suspend (A) -> Unit): Either<A, B> = this.mapLeft {
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <A, B> Either<A, B>.tapLeft(f: (A) -> Unit): Either<A, B> = this.mapLeft {
   f(it)
   it
 }
@@ -58,7 +59,7 @@ suspend fun <A, B> Either<A, B>.tapLeft(f: suspend (A) -> Unit): Either<A, B> = 
 /**
  * Performs an effect on the right side of the Either.
  */
-suspend fun <A, B> Either<A, B>.forEach(f: suspend (B) -> Unit): Unit = when (this) {
+inline fun <A, B> Either<A, B>.forEach(f: (B) -> Unit): Unit = when (this) {
   is Either.Left -> Unit
   is Either.Right -> f(this.value)
 }
@@ -66,7 +67,7 @@ suspend fun <A, B> Either<A, B>.forEach(f: suspend (B) -> Unit): Unit = when (th
 /**
  * Performs an effect on the left side of the Either.
  */
-suspend fun <A, B> Either<A, B>.leftForEach(f: suspend (A) -> Unit): Unit = when (this) {
+inline fun <A, B> Either<A, B>.leftForEach(f: (A) -> Unit): Unit = when (this) {
   is Either.Left -> f(this.value)
   is Either.Right -> Unit
 }
@@ -83,12 +84,12 @@ inline fun <A, B, C> Either<A, B>.flatTap(f: (B) -> Either<A, C>): Either<A, B> 
  * Lifts a nullable value into an Either, similar to toOption.  Must supply the left side
  * of the Either.
  */
-fun <A, B> B?.toEither(left: () -> A): Either<A, B> = this.toOption().toEither { left() }
+inline fun <A, B> B?.toEither(left: () -> A): Either<A, B> = this.toOption().toEither { left() }
 
 /**
  * Map on a nested Either Option type.
  */
-fun <E, T, V> Either<E, Option<T>>.mapOption(f: (T) -> V): Either<E, Option<V>> = this.map { it.map(f) }
+inline fun <E, T, V> Either<E, Option<T>>.mapOption(f: (T) -> V): Either<E, Option<V>> = this.map { it.map(f) }
 
 /**
  * Map right to Unit. This restores `.void()` which was deprecated by Arrow.

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
@@ -1,6 +1,5 @@
 package app.cash.quiver.extensions
 
-import arrow.core.Either
 import arrow.core.Option
 import arrow.core.Some
 import arrow.core.ValidatedNel
@@ -26,7 +25,7 @@ inline fun <T, E> Option<T>.toValidatedNel(error: () -> E): ValidatedNel<E, T> =
 /**
  * Runs a side effect if the option is a Some
  */
-suspend fun <A> Option<A>.forEach(f: suspend (A) -> Unit) = when (this) {
+inline fun <A> Option<A>.forEach(f: (A) -> Unit) = when (this) {
   is Some -> f(value)
   else -> Unit
 }


### PR DESCRIPTION
This PR is introduces **binary breaking change** by replacing `suspend` in some cases with `inline`. It is however source compatible. I am not sure how strict binary breaking changes are being dealt with atm.

It also exposes that `tapLeft` is duplicated with the Arrow API, hence `EXTENSION_SHADOWED_BY_MEMBER`