### PR TITLE
Makes logo image theme-aware

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ kotest = [
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version = "1.8.10" }
+dokkaBase = { id = "org.jetbrains.dokka:dokka-base", version = "1.8.10" }
 kotlinBinaryCompatibilityPlugin = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinBinaryCompatibilityPlugin" }
 kotlinGradlePlugin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 mavenPublishGradlePlugin = { id = "com.vanniktech.maven.publish.base", version.ref = "mavenPublishGradlePlugin" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,8 +1,15 @@
+import org.jetbrains.dokka.base.DokkaBaseConfiguration
 import org.jetbrains.dokka.gradle.DokkaTask
 import java.net.URL
 
 plugins {
   `java-library`
+}
+
+buildscript {
+  dependencies {
+    classpath(libs.plugins.dokkaBase.get().toString())
+  }
 }
 
 dependencies {
@@ -26,12 +33,16 @@ dependencies {
 
 // Copies Quiver logo into Dokka output directory, making images accessible in documentation
 tasks.register<Copy>("copyDocumentationImages") {
-  from("../images/quiver-logo-01.svg")
+  from("../images/quiver-logo-01.svg", "../images/quiver-logo-02.svg")
   into("${getRootDir()}/lib/build/dokka/html/doc-images")
 }
 
 tasks.withType<DokkaTask>().configureEach {
   dependsOn("copyDocumentationImages")
+  pluginConfiguration<org.jetbrains.dokka.base.DokkaBase, DokkaBaseConfiguration> {
+    customStyleSheets = listOf(file("custom-styles.css"))
+  }
+
   dokkaSourceSets {
     named("main") {
       moduleName.set("Quiver Library")

--- a/lib/custom-styles.css
+++ b/lib/custom-styles.css
@@ -1,0 +1,15 @@
+.theme-dark .dark-image {
+  display: block;
+}
+
+.theme-dark .light-image {
+  display: none;
+}
+
+.dark-image:not(html.theme-dark *) {
+  display: none;
+}
+
+.light-image:not(html.theme-dark *) {
+  display: block;
+}

--- a/lib/module.md
+++ b/lib/module.md
@@ -1,6 +1,7 @@
 # Module Quiver Library
 
-![](/quiver/doc-images/quiver-logo-01.svg)
+<img src="doc-images/quiver-logo-02.svg" class="dark-image">
+<img src="doc-images/quiver-logo-01.svg" class="light-image">
 
 Quiver is a library that builds upon [Arrow](https://arrow-kt.io/) to make functional programming in Kotlin even
 more accessible & delightful.


### PR DESCRIPTION
Shows the dark logo in dark mode, and the light logo in light mode!

Bonus: allows us to set a dark/light mode version of images in other documentation (e.g. diagrams).

This pull request is dedicated to @millyrowboat ✨ 

https://user-images.githubusercontent.com/1646536/227755127-aa16764b-220c-4a05-9a79-f28e48b90589.mov
