### PR TITLE
Fix Outcome.traverse/sequence

### DIFF
--- a/lib/src/main/kotlin/app/cash/quiver/Outcome.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/Outcome.kt
@@ -267,14 +267,14 @@ inline fun <E, A, EE> Outcome<E, A>.mapFailure(f: (E) -> EE): Outcome<EE, A> = w
 }
 
 fun <E, A> Outcome<E, Iterable<A>>.sequence(): List<Outcome<E, A>> = when (this) {
-  Absent,
-  is Failure -> emptyList()
+  Absent -> listOf(Absent)
+  is Failure -> listOf(this)
   is Present -> this.value.map(::Present)
 }
 
 fun <E, A> Outcome<E, Option<A>>.sequence(): Option<Outcome<E, A>> = when (this) {
-  Absent,
-  is Failure -> None
+  Absent -> Some(Absent)
+  is Failure -> Some(this)
   is Present -> this.value.map(::Present)
 }
 

--- a/lib/src/test/kotlin/app/cash/quiver/OutcomeTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/OutcomeTest.kt
@@ -340,7 +340,7 @@ class OutcomeTest : StringSpec({
     bad.sequence().shouldBeNone()
 
     val absent: Outcome<String, Option<Int>> = Absent
-    absent.sequence().shouldBeNone()
+    absent.sequence().shouldBeSome().shouldBeAbsent()
   }
 
   "Validated sequence/traverse" {
@@ -358,13 +358,13 @@ class OutcomeTest : StringSpec({
 
   "List sequence/traverse" {
     Present(listOf(1, 2, 3)).sequence().shouldBe(listOf(1.present(), 2.present(), 3.present()))
-    Present(listOf(1)).sequence() shouldBe Present(1).traverse { a: Int -> listOf(a) }
+    Present(listOf(1, 1)).sequence() shouldBe Present(1).traverse { a: Int -> listOf(a, a) }
 
     val bad: Outcome<String, List<Int>> = "bad".failure()
-    bad.sequence() shouldBe listOf()
+    bad.sequence() shouldBe listOf("bad".failure())
 
     val absent: Outcome<String, List<Int>> = Absent
-    absent.sequence() shouldBe listOf()
+    absent.sequence() shouldBe listOf(Absent)
   }
 
   "mapFailure" {


### PR DESCRIPTION
The current implementations of `traverse`/`sequence` does not respect the expected laws. Let's compare with Haskell (where `Just` is the equivalent of `Some`, and `[x]` means `listOf(x)`).

```haskell
> mapM (\x -> Just 3) (Left 2)
Just (Left 2)
> mapM (\x -> [3]) (Left 2)
[Left 2]
```

However, our current implementation would return `None` and an empty list in those cases. This PR implements the law-abiding implementations, which return `Failure` wrapped in the corresponding type instead of the "error path" of those.
