### PR TITLE
Add Either.traverse

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -160,8 +160,12 @@ public final class app/cash/quiver/extensions/EitherKt {
 	public static final fun mapOption (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun or (Larrow/core/Either;Lkotlin/jvm/functions/Function0;)Larrow/core/Either;
 	public static final fun orThrow (Larrow/core/Either;)Ljava/lang/Object;
+	public static final fun sequence (Larrow/core/Either;)Larrow/core/Option;
+	public static final fun sequence (Larrow/core/Either;)Ljava/util/List;
 	public static final fun tapLeft (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun toEither (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Larrow/core/Either;
+	public static final fun traverse (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun traverse (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public static final fun unit (Larrow/core/Either;)Larrow/core/Either;
 	public static final fun validateNotNull (Ljava/lang/Object;Larrow/core/Option;)Larrow/core/Either;
 	public static synthetic fun validateNotNull$default (Ljava/lang/Object;Larrow/core/Option;ILjava/lang/Object;)Larrow/core/Either;

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
@@ -6,7 +6,11 @@ import arrow.core.Option
 import arrow.core.Some
 import arrow.core.flatMap
 import arrow.core.getOrElse
+import arrow.core.identity
+import arrow.core.right
 import arrow.core.toOption
+import kotlin.experimental.ExperimentalTypeInference
+import app.cash.quiver.extensions.traverse as quiverTraverse
 
 /**
  * Retrieves the Right hand of an Either, or throws the Left hand error
@@ -95,3 +99,25 @@ inline fun <E, T, V> Either<E, Option<T>>.mapOption(f: (T) -> V): Either<E, Opti
  * Map right to Unit. This restores `.void()` which was deprecated by Arrow.
  */
 fun <A, B> Either<A, B>.unit() = map { }
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+inline fun <E, A, B> Either<E, A>.traverse(transform: (value: A) -> Iterable<B>): List<Either<E, B>> =
+  when (this) {
+    is Either.Left -> listOf(this)
+    is Either.Right -> transform(value).map { it.right() }
+  }
+
+fun <E, A> Either<E, Iterable<A>>.sequence(): List<Either<E, A>> = quiverTraverse(::identity)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+inline fun <E, A, B> Either<E, A>.traverse(transform: (value: A) -> Option<B>): Option<Either<E, B>> =
+  when (this) {
+    is Either.Left -> Some(this)
+    is Either.Right -> transform(value).map { it.right() }
+  }
+
+fun <E, A> Either<E, Option<A>>.sequence(): Option<Either<E, A>> = quiverTraverse(::identity)


### PR DESCRIPTION
We've decided in Arrow to continue deprecating and removing `traverse`, therefore I am PR'ing `traverse` to Quiver.
However when doing so I realised that it's not possible to conveniently replace the `traverse` method in Arrow, this is shown by `@Suppress("EXTENSION_SHADOWED_BY_MEMBER")`.

So as long as `traverse` is not actually removed in Arrow, the Kotlin compiler will always prefer the _instance method_ rather than the _extension function_. Regardless if `app.cash.quiver.extensions` is imported. This is clear from the named imports required in the tests `import app.cash.quiver.extensions.traverse as quiverTraverse`.

We can continue merging this as-is, such that it's ready for when Arrow 2.0 is released. It would be extremely easy to provide an `OpenRewrite` recipe to automatically migrate this, and I am willing to build it and expose it from Arrow org or my personal [Rewrite Arrow Project](https://github.com/nomisRev/rewrite-arrow) project.

This is the case also for `traverse` for `Option` and `Ior` but not for `Iterable`. I can create a PR adding these for `Iterable` in coming week(s).