### PR TITLE
Either, Nullable & Ior zip

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -179,7 +179,6 @@ public final class app/cash/quiver/extensions/EitherKt {
 
 public final class app/cash/quiver/extensions/IorKt {
 	public static final fun emptyCombine (Larrow/core/Option;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public static final fun flatMap (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static final fun getUnitIor ()Larrow/core/Ior;
 	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function10;)Larrow/core/Ior;
 	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function9;)Larrow/core/Ior;

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -155,6 +155,7 @@ public final class app/cash/quiver/extensions/EitherKt {
 	public static final fun asOption (Larrow/core/Either;)Larrow/core/Option;
 	public static final fun flatTap (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun forEach (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)V
+	public static final fun getRightUnit ()Larrow/core/Either;
 	public static final fun leftAsOption (Larrow/core/Either;)Larrow/core/Option;
 	public static final fun leftForEach (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)V
 	public static final fun mapOption (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
@@ -165,6 +166,30 @@ public final class app/cash/quiver/extensions/EitherKt {
 	public static final fun unit (Larrow/core/Either;)Larrow/core/Either;
 	public static final fun validateNotNull (Ljava/lang/Object;Larrow/core/Option;)Larrow/core/Either;
 	public static synthetic fun validateNotNull$default (Ljava/lang/Object;Larrow/core/Option;ILjava/lang/Object;)Larrow/core/Either;
+	public static final fun zip (Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Lkotlin/jvm/functions/Function10;)Larrow/core/Either;
+	public static final fun zip (Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Lkotlin/jvm/functions/Function9;)Larrow/core/Either;
+	public static final fun zip (Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Lkotlin/jvm/functions/Function8;)Larrow/core/Either;
+	public static final fun zip (Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Lkotlin/jvm/functions/Function7;)Larrow/core/Either;
+	public static final fun zip (Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Lkotlin/jvm/functions/Function6;)Larrow/core/Either;
+	public static final fun zip (Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Lkotlin/jvm/functions/Function5;)Larrow/core/Either;
+	public static final fun zip (Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Lkotlin/jvm/functions/Function4;)Larrow/core/Either;
+	public static final fun zip (Larrow/core/Either;Larrow/core/Either;Larrow/core/Either;Lkotlin/jvm/functions/Function3;)Larrow/core/Either;
+	public static final fun zip (Larrow/core/Either;Larrow/core/Either;Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
+}
+
+public final class app/cash/quiver/extensions/IorKt {
+	public static final fun emptyCombine (Larrow/core/Option;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun flatMap (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
+	public static final fun getUnitIor ()Larrow/core/Ior;
+	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function10;)Larrow/core/Ior;
+	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function9;)Larrow/core/Ior;
+	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function8;)Larrow/core/Ior;
+	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function7;)Larrow/core/Ior;
+	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function6;)Larrow/core/Ior;
+	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function5;)Larrow/core/Ior;
+	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function4;)Larrow/core/Ior;
+	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Larrow/core/Ior;Lkotlin/jvm/functions/Function3;)Larrow/core/Ior;
+	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Lkotlin/jvm/functions/Function2;)Larrow/core/Ior;
 }
 
 public final class app/cash/quiver/extensions/ListKt {
@@ -179,6 +204,19 @@ public final class app/cash/quiver/extensions/MapKt {
 
 public final class app/cash/quiver/extensions/NonEmptyListKt {
 	public static final fun mapNotNone (Larrow/core/NonEmptyList;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+}
+
+public final class app/cash/quiver/extensions/Nullable {
+	public static final field INSTANCE Lapp/cash/quiver/extensions/Nullable;
+	public static final fun zip (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function10;)Ljava/lang/Object;
+	public static final fun zip (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function9;)Ljava/lang/Object;
+	public static final fun zip (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function8;)Ljava/lang/Object;
+	public static final fun zip (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function7;)Ljava/lang/Object;
+	public static final fun zip (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function6;)Ljava/lang/Object;
+	public static final fun zip (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function5;)Ljava/lang/Object;
+	public static final fun zip (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;)Ljava/lang/Object;
+	public static final fun zip (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)Ljava/lang/Object;
+	public static final fun zip (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 }
 
 public final class app/cash/quiver/extensions/OptionKt {

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
@@ -95,3 +95,164 @@ inline fun <E, T, V> Either<E, Option<T>>.mapOption(f: (T) -> V): Either<E, Opti
  * Map right to Unit. This restores `.void()` which was deprecated by Arrow.
  */
 fun <A, B> Either<A, B>.unit() = map { }
+
+@PublishedApi
+internal val rightUnit: Either<Nothing, Unit> = Either.Right(Unit)
+
+inline fun <A, B, C, D> Either<A, B>.zip(b: Either<A, C>, transform: (B, C) -> D): Either<A, D> =
+  flatMap { a ->
+    b.map { bb -> transform(a, bb) }
+  }
+
+inline fun <A, B, C, D, E> Either<A, B>.zip(
+  b: Either<A, C>,
+  c: Either<A, D>,
+  transform: (B, C, D) -> E,
+): Either<A, E> =
+  zip(
+    b,
+    c,
+    rightUnit,
+    rightUnit,
+    rightUnit,
+    rightUnit,
+    rightUnit,
+    rightUnit,
+    rightUnit
+  ) { a, bb, cc, _, _, _, _, _, _, _ -> transform(a, bb, cc) }
+
+inline fun <A, B, C, D, E, F> Either<A, B>.zip(
+  b: Either<A, C>,
+  c: Either<A, D>,
+  d: Either<A, E>,
+  transform: (B, C, D, E) -> F,
+): Either<A, F> =
+  zip(
+    b,
+    c,
+    d,
+    rightUnit,
+    rightUnit,
+    rightUnit,
+    rightUnit,
+    rightUnit,
+    rightUnit
+  ) { a, bb, cc, dd, _, _, _, _, _, _ -> transform(a, bb, cc, dd) }
+
+inline fun <A, B, C, D, E, F, G> Either<A, B>.zip(
+  b: Either<A, C>,
+  c: Either<A, D>,
+  d: Either<A, E>,
+  e: Either<A, F>,
+  transform: (B, C, D, E, F) -> G,
+): Either<A, G> =
+  zip(
+    b,
+    c,
+    d,
+    e,
+    rightUnit,
+    rightUnit,
+    rightUnit,
+    rightUnit,
+    rightUnit
+  ) { a, bb, cc, dd, ee, _, _, _, _, _ -> transform(a, bb, cc, dd, ee) }
+
+inline fun <A, B, C, D, E, F, G, H> Either<A, B>.zip(
+  b: Either<A, C>,
+  c: Either<A, D>,
+  d: Either<A, E>,
+  e: Either<A, F>,
+  f: Either<A, G>,
+  transform: (B, C, D, E, F, G) -> H,
+): Either<A, H> =
+  zip(b, c, d, e, f, rightUnit, rightUnit, rightUnit, rightUnit) { a, bb, cc, dd, ee, ff, _, _, _, _ ->
+    transform(
+      a,
+      bb,
+      cc,
+      dd,
+      ee,
+      ff
+    )
+  }
+
+inline fun <A, B, C, D, E, F, G, H, I> Either<A, B>.zip(
+  b: Either<A, C>,
+  c: Either<A, D>,
+  d: Either<A, E>,
+  e: Either<A, F>,
+  f: Either<A, G>,
+  g: Either<A, H>,
+  transform: (B, C, D, E, F, G, H) -> I,
+): Either<A, I> =
+  zip(b, c, d, e, f, g, rightUnit, rightUnit, rightUnit) { a, bb, cc, dd, ee, ff, gg, _, _, _ ->
+    transform(
+      a,
+      bb,
+      cc,
+      dd,
+      ee,
+      ff,
+      gg
+    )
+  }
+
+inline fun <A, B, C, D, E, F, G, H, I, J> Either<A, B>.zip(
+  b: Either<A, C>,
+  c: Either<A, D>,
+  d: Either<A, E>,
+  e: Either<A, F>,
+  f: Either<A, G>,
+  g: Either<A, H>,
+  h: Either<A, I>,
+  transform: (B, C, D, E, F, G, H, I) -> J,
+): Either<A, J> =
+  zip(b, c, d, e, f, g, h, rightUnit, rightUnit) { a, bb, cc, dd, ee, ff, gg, hh, _, _ -> transform(a, bb, cc, dd, ee, ff, gg, hh) }
+
+inline fun <A, B, C, D, E, F, G, H, I, J, K> Either<A, B>.zip(
+  b: Either<A, C>,
+  c: Either<A, D>,
+  d: Either<A, E>,
+  e: Either<A, F>,
+  f: Either<A, G>,
+  g: Either<A, H>,
+  h: Either<A, I>,
+  i: Either<A, J>,
+  transform: (B, C, D, E, F, G, H, I, J) -> K,
+): Either<A, K> =
+  zip(b, c, d, e, f, g, h, i, rightUnit) { a, bb, cc, dd, ee, ff, gg, hh, ii, _ -> transform(a, bb, cc, dd, ee, ff, gg, hh, ii) }
+
+inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Either<A, B>.zip(
+  b: Either<A, C>,
+  c: Either<A, D>,
+  d: Either<A, E>,
+  e: Either<A, F>,
+  f: Either<A, G>,
+  g: Either<A, H>,
+  h: Either<A, I>,
+  i: Either<A, J>,
+  j: Either<A, K>,
+  transform: (B, C, D, E, F, G, H, I, J, K) -> L,
+): Either<A, L> =
+  flatMap { a ->
+    b.flatMap { bb ->
+      c.flatMap { cc ->
+        d.flatMap { dd ->
+          e.flatMap { ee ->
+            f.flatMap { ff ->
+              g.flatMap { gg ->
+                h.flatMap { hh ->
+                  i.flatMap { ii ->
+                    j.map { jj ->
+                      transform(a, bb, cc, dd, ee, ff, gg, hh, ii, jj)
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Ior.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Ior.kt
@@ -1,6 +1,12 @@
 package app.cash.quiver.extensions
 
 import arrow.core.Ior
+import arrow.core.Ior.Both
+import arrow.core.Ior.Left
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.some
 
 @PublishedApi
 internal val unitIor: Ior<Nothing, Unit> = Ior.Right(Unit)
@@ -10,7 +16,18 @@ inline fun <A, B, C, D> Ior<A, B>.zip(
   c: Ior<A, C>,
   map: (B, C) -> D
 ): Ior<A, D> =
-  zip(combine, c, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+  zip(
+    combine,
+    c,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor
+  ) { b, cc, _, _, _, _, _, _, _, _ -> map(b, cc) }
 
 inline fun <A, B, C, D, E> Ior<A, B>.zip(
   crossinline combine: (A, A) -> A,
@@ -18,7 +35,18 @@ inline fun <A, B, C, D, E> Ior<A, B>.zip(
   d: Ior<A, D>,
   map: (B, C, D) -> E
 ): Ior<A, E> =
-  zip(combine, c, d, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+  zip(
+    combine,
+    c,
+    d,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor
+  ) { b, cc, dd, _, _, _, _, _, _, _ -> map(b, cc, dd) }
 
 inline fun <A, B, C, D, E, F> Ior<A, B>.zip(
   crossinline combine: (A, A) -> A,
@@ -27,7 +55,18 @@ inline fun <A, B, C, D, E, F> Ior<A, B>.zip(
   e: Ior<A, E>,
   map: (B, C, D, E) -> F
 ): Ior<A, F> =
-  zip(combine, c, d, e, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
+  zip(
+    combine,
+    c,
+    d,
+    e,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor,
+    unitIor
+  ) { b, cc, dd, ee, _, _, _, _, _, _ -> map(b, cc, dd, ee) }
 
 inline fun <A, B, C, D, E, F, G> Ior<A, B>.zip(
   crossinline combine: (A, A) -> A,
@@ -37,7 +76,15 @@ inline fun <A, B, C, D, E, F, G> Ior<A, B>.zip(
   f: Ior<A, F>,
   map: (B, C, D, E, F) -> G
 ): Ior<A, G> =
-  zip(combine, c, d, e, f, unitIor, unitIor, unitIor, unitIor, unitIor) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
+  zip(combine, c, d, e, f, unitIor, unitIor, unitIor, unitIor, unitIor) { b, cc, dd, ee, ff, _, _, _, _, _ ->
+    map(
+      b,
+      cc,
+      dd,
+      ee,
+      ff
+    )
+  }
 
 inline fun <A, B, C, D, E, F, G, H> Ior<A, B>.zip(
   crossinline combine: (A, A) -> A,
@@ -48,7 +95,16 @@ inline fun <A, B, C, D, E, F, G, H> Ior<A, B>.zip(
   g: Ior<A, G>,
   map: (B, C, D, E, F, G) -> H
 ): Ior<A, H> =
-  zip(combine, c, d, e, f, g, unitIor, unitIor, unitIor, unitIor) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
+  zip(combine, c, d, e, f, g, unitIor, unitIor, unitIor, unitIor) { b, cc, dd, ee, ff, gg, _, _, _, _ ->
+    map(
+      b,
+      cc,
+      dd,
+      ee,
+      ff,
+      gg
+    )
+  }
 
 inline fun <A, B, C, D, E, F, G, H, I> Ior<A, B>.zip(
   crossinline combine: (A, A) -> A,
@@ -60,7 +116,17 @@ inline fun <A, B, C, D, E, F, G, H, I> Ior<A, B>.zip(
   h: Ior<A, H>,
   map: (B, C, D, E, F, G, H) -> I
 ): Ior<A, I> =
-  zip(combine, c, d, e, f, g, h, unitIor, unitIor, unitIor) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
+  zip(combine, c, d, e, f, g, h, unitIor, unitIor, unitIor) { b, cc, dd, ee, ff, gg, hh, _, _, _ ->
+    map(
+      b,
+      cc,
+      dd,
+      ee,
+      ff,
+      gg,
+      hh
+    )
+  }
 
 inline fun <A, B, C, D, E, F, G, H, I, J> Ior<A, B>.zip(
   crossinline combine: (A, A) -> A,
@@ -73,7 +139,18 @@ inline fun <A, B, C, D, E, F, G, H, I, J> Ior<A, B>.zip(
   i: Ior<A, I>,
   map: (B, C, D, E, F, G, H, I) -> J
 ): Ior<A, J> =
-  zip(combine, c, d, e, f, g, h, i, unitIor, unitIor) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
+  zip(combine, c, d, e, f, g, h, i, unitIor, unitIor) { b, cc, dd, ee, ff, gg, hh, ii, _, _ ->
+    map(
+      b,
+      cc,
+      dd,
+      ee,
+      ff,
+      gg,
+      hh,
+      ii
+    )
+  }
 
 inline fun <A, B, C, D, E, F, G, H, I, J, K> Ior<A, B>.zip(
   crossinline combine: (A, A) -> A,
@@ -87,20 +164,33 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K> Ior<A, B>.zip(
   j: Ior<A, J>,
   map: (B, C, D, E, F, G, H, I, J) -> K
 ): Ior<A, K> =
-  zip(combine, c, d, e, f, g, h, i, j, unitIor) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
+  zip(combine, c, d, e, f, g, h, i, j, unitIor) { b, cc, dd, ee, ff, gg, hh, ii, jj, _ ->
+    map(
+      b,
+      cc,
+      dd,
+      ee,
+      ff,
+      gg,
+      hh,
+      ii,
+      jj
+    )
+  }
 
 inline fun <A, B, D> Ior<A, B>.flatMap(combine: (A, A) -> A, f: (B) -> Ior<A, D>): Ior<A, D> =
   when (this) {
-    is Ior.Left -> this
+    is Left -> this
     is Ior.Right -> f(value)
-    is Ior.Both ->
+    is Both ->
       f(this@flatMap.rightValue).fold(
-        { a -> Ior.Left(combine(this@flatMap.leftValue, a)) },
-        { d -> Ior.Both(this@flatMap.leftValue, d) },
-        { ll, rr -> Ior.Both(combine(this@flatMap.leftValue, ll), rr) }
+        { a -> Left(combine(this@flatMap.leftValue, a)) },
+        { d -> Both(this@flatMap.leftValue, d) },
+        { ll, rr -> Both(combine(this@flatMap.leftValue, ll), rr) }
       )
   }
 
+@Suppress("UNCHECKED_CAST")
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Ior<A, B>.zip(
   crossinline combine: (A, A) -> A,
   c: Ior<A, C>,
@@ -113,24 +203,75 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Ior<A, B>.zip(
   j: Ior<A, J>,
   k: Ior<A, K>,
   transform: (B, C, D, E, F, G, H, I, J, K) -> L
-): Ior<A, L> = flatMap(combine) { a ->
-    c.flatMap(combine) { bb ->
-      d.flatMap(combine) { cc ->
-        e.flatMap(combine) { dd ->
-          f.flatMap(combine) { ee ->
-            g.flatMap(combine) { ff ->
-              h.flatMap(combine) { gg ->
-                i.flatMap(combine) { hh ->
-                  j.flatMap(combine) { ii ->
-                    k.map { jj ->
-                      transform(a, bb, cc, dd, ee, ff, gg, hh, ii, jj)
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+): Ior<A, L> {
+  val right: Option<L> = if (
+    (this@zip.isRight || this@zip.isBoth) &&
+    (c.isRight || c.isBoth) &&
+    (d.isRight || d.isBoth) &&
+    (e.isRight || e.isBoth) &&
+    (f.isRight || f.isBoth) &&
+    (g.isRight || g.isBoth) &&
+    (h.isRight || h.isBoth) &&
+    (i.isRight || i.isBoth) &&
+    (j.isRight || j.isBoth) &&
+    (k.isRight || k.isBoth)
+  ) {
+    transform(
+      this@zip.orNull() as B,
+      c.orNull() as C,
+      d.orNull() as D,
+      e.orNull() as E,
+      f.orNull() as F,
+      g.orNull() as G,
+      h.orNull() as H,
+      i.orNull() as I,
+      j.orNull() as J,
+      k.orNull() as K
+    ).some()
+  } else None
+
+  var left: Option<A> = None
+
+  if (this@zip is Left) return@zip Left(this@zip.value)
+  left = if (this@zip is Both) Some(this@zip.leftValue) else left
+
+  if (c is Left) return@zip Left(left.emptyCombine(c.value, combine))
+  left = if (c is Both) Some(left.emptyCombine(c.leftValue, combine)) else left
+
+  if (d is Left) return@zip Left(left.emptyCombine(d.value, combine))
+  left = if (d is Both) Some(left.emptyCombine(d.leftValue, combine)) else left
+
+  if (e is Left) return@zip Left(left.emptyCombine(e.value, combine))
+  left = if (e is Both) Some(left.emptyCombine(e.leftValue, combine)) else left
+
+  if (f is Left) return@zip Left(left.emptyCombine(f.value, combine))
+  left = if (f is Both) Some(left.emptyCombine(f.leftValue, combine)) else left
+
+  if (g is Left) return@zip Left(left.emptyCombine(g.value, combine))
+  left = if (g is Both) Some(left.emptyCombine(g.leftValue, combine)) else left
+
+  if (h is Left) return@zip Left(left.emptyCombine(h.value, combine))
+  left = if (h is Both) Some(left.emptyCombine(h.leftValue, combine)) else left
+
+  if (i is Left) return@zip Left(left.emptyCombine(i.value, combine))
+  left = if (i is Both) Some(left.emptyCombine(i.leftValue, combine)) else left
+
+  if (j is Left) return@zip Left(left.emptyCombine(j.value, combine))
+  left = if (j is Both) Some(left.emptyCombine(j.leftValue, combine)) else left
+
+  if (k is Left) return@zip Left(left.emptyCombine(k.value, combine))
+  left = if (k is Both)Some(left.emptyCombine(k.leftValue, combine)) else left
+
+  return when {
+    right != None && left == None -> Ior.Right(right as L)
+    right != None && left != None -> Both(left as A, right as L)
+    right == None && left != None -> Left(left as A)
+    else -> throw IllegalStateException("Ior.zip should not be possible to reach this state")
+  }
+}
+
+inline fun <A> Option<A>.emptyCombine(other: A, combine: (A, A) -> A): A =
+  when (this) {
+    is Some -> combine(this.value, other)
+    is None -> other
   }

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Ior.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Ior.kt
@@ -1,0 +1,136 @@
+package app.cash.quiver.extensions
+
+import arrow.core.Ior
+
+@PublishedApi
+internal val unitIor: Ior<Nothing, Unit> = Ior.Right(Unit)
+
+inline fun <A, B, C, D> Ior<A, B>.zip(
+  crossinline combine: (A, A) -> A,
+  c: Ior<A, C>,
+  map: (B, C) -> D
+): Ior<A, D> =
+  zip(combine, c, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+
+inline fun <A, B, C, D, E> Ior<A, B>.zip(
+  crossinline combine: (A, A) -> A,
+  c: Ior<A, C>,
+  d: Ior<A, D>,
+  map: (B, C, D) -> E
+): Ior<A, E> =
+  zip(combine, c, d, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+
+inline fun <A, B, C, D, E, F> Ior<A, B>.zip(
+  crossinline combine: (A, A) -> A,
+  c: Ior<A, C>,
+  d: Ior<A, D>,
+  e: Ior<A, E>,
+  map: (B, C, D, E) -> F
+): Ior<A, F> =
+  zip(combine, c, d, e, unitIor, unitIor, unitIor, unitIor, unitIor, unitIor) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
+
+inline fun <A, B, C, D, E, F, G> Ior<A, B>.zip(
+  crossinline combine: (A, A) -> A,
+  c: Ior<A, C>,
+  d: Ior<A, D>,
+  e: Ior<A, E>,
+  f: Ior<A, F>,
+  map: (B, C, D, E, F) -> G
+): Ior<A, G> =
+  zip(combine, c, d, e, f, unitIor, unitIor, unitIor, unitIor, unitIor) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
+
+inline fun <A, B, C, D, E, F, G, H> Ior<A, B>.zip(
+  crossinline combine: (A, A) -> A,
+  c: Ior<A, C>,
+  d: Ior<A, D>,
+  e: Ior<A, E>,
+  f: Ior<A, F>,
+  g: Ior<A, G>,
+  map: (B, C, D, E, F, G) -> H
+): Ior<A, H> =
+  zip(combine, c, d, e, f, g, unitIor, unitIor, unitIor, unitIor) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
+
+inline fun <A, B, C, D, E, F, G, H, I> Ior<A, B>.zip(
+  crossinline combine: (A, A) -> A,
+  c: Ior<A, C>,
+  d: Ior<A, D>,
+  e: Ior<A, E>,
+  f: Ior<A, F>,
+  g: Ior<A, G>,
+  h: Ior<A, H>,
+  map: (B, C, D, E, F, G, H) -> I
+): Ior<A, I> =
+  zip(combine, c, d, e, f, g, h, unitIor, unitIor, unitIor) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
+
+inline fun <A, B, C, D, E, F, G, H, I, J> Ior<A, B>.zip(
+  crossinline combine: (A, A) -> A,
+  c: Ior<A, C>,
+  d: Ior<A, D>,
+  e: Ior<A, E>,
+  f: Ior<A, F>,
+  g: Ior<A, G>,
+  h: Ior<A, H>,
+  i: Ior<A, I>,
+  map: (B, C, D, E, F, G, H, I) -> J
+): Ior<A, J> =
+  zip(combine, c, d, e, f, g, h, i, unitIor, unitIor) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
+
+inline fun <A, B, C, D, E, F, G, H, I, J, K> Ior<A, B>.zip(
+  crossinline combine: (A, A) -> A,
+  c: Ior<A, C>,
+  d: Ior<A, D>,
+  e: Ior<A, E>,
+  f: Ior<A, F>,
+  g: Ior<A, G>,
+  h: Ior<A, H>,
+  i: Ior<A, I>,
+  j: Ior<A, J>,
+  map: (B, C, D, E, F, G, H, I, J) -> K
+): Ior<A, K> =
+  zip(combine, c, d, e, f, g, h, i, j, unitIor) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
+
+inline fun <A, B, D> Ior<A, B>.flatMap(combine: (A, A) -> A, f: (B) -> Ior<A, D>): Ior<A, D> =
+  when (this) {
+    is Ior.Left -> this
+    is Ior.Right -> f(value)
+    is Ior.Both ->
+      f(this@flatMap.rightValue).fold(
+        { a -> Ior.Left(combine(this@flatMap.leftValue, a)) },
+        { d -> Ior.Both(this@flatMap.leftValue, d) },
+        { ll, rr -> Ior.Both(combine(this@flatMap.leftValue, ll), rr) }
+      )
+  }
+
+inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Ior<A, B>.zip(
+  crossinline combine: (A, A) -> A,
+  c: Ior<A, C>,
+  d: Ior<A, D>,
+  e: Ior<A, E>,
+  f: Ior<A, F>,
+  g: Ior<A, G>,
+  h: Ior<A, H>,
+  i: Ior<A, I>,
+  j: Ior<A, J>,
+  k: Ior<A, K>,
+  transform: (B, C, D, E, F, G, H, I, J, K) -> L
+): Ior<A, L> = flatMap(combine) { a ->
+    c.flatMap(combine) { bb ->
+      d.flatMap(combine) { cc ->
+        e.flatMap(combine) { dd ->
+          f.flatMap(combine) { ee ->
+            g.flatMap(combine) { ff ->
+              h.flatMap(combine) { gg ->
+                i.flatMap(combine) { hh ->
+                  j.flatMap(combine) { ii ->
+                    k.map { jj ->
+                      transform(a, bb, cc, dd, ee, ff, gg, hh, ii, jj)
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Ior.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Ior.kt
@@ -250,11 +250,15 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Ior<A, B>.zip(
   if (k is Left) return@zip Left(left.emptyCombine(k.value, combine))
   left = if (k is Both)Some(left.emptyCombine(k.leftValue, combine)) else left
 
-  return when {
-    right != None && left == None -> Ior.Right(right as L)
-    right != None && left != None -> Both(left as A, right as L)
-    right == None && left != None -> Left(left as A)
-    else -> throw IllegalStateException("Ior.zip should not be possible to reach this state")
+  return when(right) {
+    is Some -> when(left) {
+      is Some -> Both(left.value, right.value)
+      is None -> Ior.Right(right.value)
+    }
+    None -> when(left) {
+      is Some -> Left(left.value)
+      is None -> throw IllegalStateException("Ior.zip should not be possible to reach this state")
+    }
   }
 }
 

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Ior.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Ior.kt
@@ -178,18 +178,6 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K> Ior<A, B>.zip(
     )
   }
 
-inline fun <A, B, D> Ior<A, B>.flatMap(combine: (A, A) -> A, f: (B) -> Ior<A, D>): Ior<A, D> =
-  when (this) {
-    is Left -> this
-    is Ior.Right -> f(value)
-    is Both ->
-      f(this@flatMap.rightValue).fold(
-        { a -> Left(combine(this@flatMap.leftValue, a)) },
-        { d -> Both(this@flatMap.leftValue, d) },
-        { ll, rr -> Both(combine(this@flatMap.leftValue, ll), rr) }
-      )
-  }
-
 @Suppress("UNCHECKED_CAST")
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Ior<A, B>.zip(
   crossinline combine: (A, A) -> A,
@@ -270,7 +258,8 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Ior<A, B>.zip(
   }
 }
 
-inline fun <A> Option<A>.emptyCombine(other: A, combine: (A, A) -> A): A =
+@PublishedApi
+internal inline fun <A> Option<A>.emptyCombine(other: A, combine: (A, A) -> A): A =
   when (this) {
     is Some -> combine(this.value, other)
     is None -> other

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Nullable.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Nullable.kt
@@ -1,0 +1,117 @@
+package app.cash.quiver.extensions
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.jvm.JvmStatic
+
+@OptIn(ExperimentalContracts::class)
+object Nullable {
+
+  @JvmStatic
+  inline fun <A, B, R> zip(a: A?, b: B?, transform: (A, B) -> R): R? {
+    contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
+    return zip(a, b, Unit) { aa, bb, _ -> transform(aa, bb) }
+  }
+
+  @JvmStatic
+  inline fun <A, B, C, R> zip(a: A?, b: B?, c: C?, transform: (A, B, C) -> R): R? {
+    contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
+    return zip(a, b, c, Unit) { aa, bb, cc, _ -> transform(aa, bb, cc) }
+  }
+
+  @JvmStatic
+  inline fun <A, B, C, D, R> zip(a: A?, b: B?, c: C?, d: D?, transform: (A, B, C, D) -> R): R? {
+    contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
+    return zip(a, b, c, d, Unit) { aa, bb, cc, dd, _ -> transform(aa, bb, cc, dd) }
+  }
+
+  @JvmStatic
+  inline fun <A, B, C, D, E, R> zip(a: A?, b: B?, c: C?, d: D?, e: E?, transform: (A, B, C, D, E) -> R): R? {
+    contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
+    return zip(a, b, c, d, e, Unit) { aa, bb, cc, dd, ee, _ -> transform(aa, bb, cc, dd, ee) }
+  }
+
+  @JvmStatic
+  inline fun <A, B, C, D, E, F, R> zip(
+    a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, transform: (A, B, C, D, E, F) -> R
+  ): R? {
+    contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
+    return zip(a, b, c, d, e, f, Unit) { aa, bb, cc, dd, ee, ff, _ -> transform(aa, bb, cc, dd, ee, ff) }
+  }
+
+  @JvmStatic
+  inline fun <A, B, C, D, E, F, G, R> zip(
+    a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, transform: (A, B, C, D, E, F, G) -> R
+  ): R? {
+    contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
+    return zip(a, b, c, d, e, f, g, Unit) { aa, bb, cc, dd, ee, ff, gg, _ -> transform(aa, bb, cc, dd, ee, ff, gg) }
+  }
+
+  @JvmStatic
+  inline fun <A, B, C, D, E, F, G, H, R> zip(
+    a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, transform: (A, B, C, D, E, F, G, H) -> R
+  ): R? {
+    contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
+    return zip(a, b, c, d, e, f, g, h, Unit) { aa, bb, cc, dd, ee, ff, gg, hh, _ ->
+      transform(
+        aa,
+        bb,
+        cc,
+        dd,
+        ee,
+        ff,
+        gg,
+        hh
+      )
+    }
+  }
+
+  @JvmStatic
+  inline fun <A, B, C, D, E, F, G, H, I, R> zip(
+    a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, i: I?, transform: (A, B, C, D, E, F, G, H, I) -> R
+  ): R? {
+    contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
+    return zip(a, b, c, d, e, f, g, h, i, Unit) { aa, bb, cc, dd, ee, ff, gg, hh, ii, _ ->
+      transform(
+        aa,
+        bb,
+        cc,
+        dd,
+        ee,
+        ff,
+        gg,
+        hh,
+        ii
+      )
+    }
+  }
+
+  @JvmStatic
+  inline fun <A, B, C, D, E, F, G, H, I, J, R> zip(
+    a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, i: I?, j: J?, transform: (A, B, C, D, E, F, G, H, I, J) -> R
+  ): R? {
+    contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
+    return a?.let { aa ->
+      b?.let { bb ->
+        c?.let { cc ->
+          d?.let { dd ->
+            e?.let { ee ->
+              f?.let { ff ->
+                g?.let { gg ->
+                  h?.let { hh ->
+                    i?.let { ii ->
+                      j?.let { jj ->
+                        transform(aa, bb, cc, dd, ee, ff, gg, hh, ii, jj)
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/EitherTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/EitherTest.kt
@@ -110,7 +110,7 @@ class EitherTest : StringSpec({
       val res = a.zip(b, c, d, e, f, g, h, i, j) { aa, bb, cc, dd, ee, ff, gg, hh, ii, jj ->
         aa + bb + cc + dd + ee + ff + gg + hh + ii + jj
       }
-      val expected = listOf(a, b, c, d, e, f, g, h, i, j).firstOrNull { it.isLeft() }?.left()
+      val expected = listOf(a, b, c, d, e, f, g, h, i, j).firstOrNull { it.isLeft() }
         ?: listOf(a, b, c, d, e, f, g, h, i, j).mapNotNull { it.getOrNull() }.sum().right()
 
       res shouldBe expected

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/EitherTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/EitherTest.kt
@@ -12,6 +12,10 @@ import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.assertions.arrow.core.shouldBeSome
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arrow.core.either
+import io.kotest.property.checkAll
 import org.junit.jupiter.api.assertThrows
 
 class EitherTest : StringSpec({
@@ -81,6 +85,36 @@ class EitherTest : StringSpec({
   "validateNotNull is left if value is null - with label" {
     val value: String? = null
     value.validateNotNull("label".some()).shouldBeLeft(IllegalArgumentException("Value (`label`) should not be null"))
+  }
+  "zip2" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      a.right().zip(b.right()) { aa, bb -> aa + bb }.shouldBeRight(a + b)
+      a.right().zip(b.left()) { aa, bb: Int -> aa + bb }.shouldBeLeft(b)
+      a.left().zip(b.right()) { aa: Int, bb -> aa + bb }.shouldBeLeft(a)
+      a.left().zip(b.left()) { aa: Int, bb: Int -> aa + bb }.shouldBeLeft(a)
+    }
+  }
+  "zip10" {
+    checkAll(
+      Arb.either(Arb.int(), Arb.int()),
+      Arb.either(Arb.int(), Arb.int()),
+      Arb.either(Arb.int(), Arb.int()),
+      Arb.either(Arb.int(), Arb.int()),
+      Arb.either(Arb.int(), Arb.int()),
+      Arb.either(Arb.int(), Arb.int()),
+      Arb.either(Arb.int(), Arb.int()),
+      Arb.either(Arb.int(), Arb.int()),
+      Arb.either(Arb.int(), Arb.int()),
+      Arb.either(Arb.int(), Arb.int())
+    ) { a, b, c, d, e, f, g, h, i, j ->
+      val res = a.zip(b, c, d, e, f, g, h, i, j) { aa, bb, cc, dd, ee, ff, gg, hh, ii, jj ->
+        aa + bb + cc + dd + ee + ff + gg + hh + ii + jj
+      }
+      val expected = listOf(a, b, c, d, e, f, g, h, i, j).firstOrNull { it.isLeft() }?.left()
+        ?: listOf(a, b, c, d, e, f, g, h, i, j).mapNotNull { it.getOrNull() }.sum().right()
+
+      res shouldBe expected
+    }
   }
 })
 

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/IorTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/IorTest.kt
@@ -1,0 +1,44 @@
+package app.cash.quiver.extensions
+
+import app.cash.quiver.arb.ior
+import arrow.core.Ior
+import arrow.core.leftIor
+import arrow.core.rightIor
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+
+class IorTest : StringSpec({
+  "zip10" {
+    checkAll(
+      Arb.ior(Arb.int(), Arb.int()),
+      Arb.ior(Arb.int(), Arb.int()),
+      Arb.ior(Arb.int(), Arb.int()),
+      Arb.ior(Arb.int(), Arb.int()),
+      Arb.ior(Arb.int(), Arb.int()),
+      Arb.ior(Arb.int(), Arb.int()),
+      Arb.ior(Arb.int(), Arb.int()),
+      Arb.ior(Arb.int(), Arb.int()),
+      Arb.ior(Arb.int(), Arb.int()),
+      Arb.ior(Arb.int(), Arb.int())
+    ) { a, b, c, d, e, f, g, h, i, j ->
+      val res = a.zip(Int::plus, b, c, d, e, f, g, h, i, j) { aa, bb, cc, dd, ee, ff, gg, hh, ii, jj ->
+        aa + bb + cc + dd + ee + ff + gg + hh + ii + jj
+      }
+
+      val all = listOf(a, b, c, d, e, f, g, h, i, j)
+      val allLeft = all.mapNotNull { it.leftOrNull() }
+      val allRight = all.mapNotNull { it.orNull() }
+
+      val expected = when {
+        allLeft.isEmpty() -> allRight.sum().rightIor()
+        allRight.isEmpty() -> allLeft.sum().leftIor()
+        else -> Ior.Both(allLeft.sum(), allRight.sum())
+      }
+
+      res shouldBe expected
+    }
+  }
+})

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/IorTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/IorTest.kt
@@ -13,29 +13,35 @@ import io.kotest.property.checkAll
 class IorTest : StringSpec({
   "zip10" {
     checkAll(
-      Arb.ior(Arb.int(), Arb.int()),
-      Arb.ior(Arb.int(), Arb.int()),
-      Arb.ior(Arb.int(), Arb.int()),
-      Arb.ior(Arb.int(), Arb.int()),
-      Arb.ior(Arb.int(), Arb.int()),
-      Arb.ior(Arb.int(), Arb.int()),
-      Arb.ior(Arb.int(), Arb.int()),
-      Arb.ior(Arb.int(), Arb.int()),
-      Arb.ior(Arb.int(), Arb.int()),
-      Arb.ior(Arb.int(), Arb.int())
+      Arb.ior(Arb.int(0..100), Arb.int()),
+      Arb.ior(Arb.int(0..100), Arb.int()),
+      Arb.ior(Arb.int(0..100), Arb.int()),
+      Arb.ior(Arb.int(0..100), Arb.int()),
+      Arb.ior(Arb.int(0..100), Arb.int()),
+      Arb.ior(Arb.int(0..100), Arb.int()),
+      Arb.ior(Arb.int(0..100), Arb.int()),
+      Arb.ior(Arb.int(0..100), Arb.int()),
+      Arb.ior(Arb.int(0..100), Arb.int()),
+      Arb.ior(Arb.int(0..100), Arb.int())
     ) { a, b, c, d, e, f, g, h, i, j ->
       val res = a.zip(Int::plus, b, c, d, e, f, g, h, i, j) { aa, bb, cc, dd, ee, ff, gg, hh, ii, jj ->
         aa + bb + cc + dd + ee + ff + gg + hh + ii + jj
       }
-
       val all = listOf(a, b, c, d, e, f, g, h, i, j)
-      val allLeft = all.mapNotNull { it.leftOrNull() }
-      val allRight = all.mapNotNull { it.orNull() }
-
-      val expected = when {
-        allLeft.isEmpty() -> allRight.sum().rightIor()
-        allRight.isEmpty() -> allLeft.sum().leftIor()
-        else -> Ior.Both(allLeft.sum(), allRight.sum())
+      val expected = all.fold<Ior<Int, Int>, Ior<Int, Int>>(Ior.Right(0)) { acc, curr ->
+        when (acc) {
+          is Ior.Left -> acc // stop accumulating if a Left is encountered
+          is Ior.Right -> curr.fold(
+            { Ior.Left(it) },
+            { Ior.Right(acc.value + it) },
+            { l, r -> Ior.Both(l, acc.value + r) }
+          )
+          is Ior.Both -> curr.fold(
+            { Ior.Left(acc.leftValue + it) },
+            { Ior.Both(acc.leftValue, it + acc.rightValue) },
+            { l, r -> Ior.Both(acc.leftValue + l, acc.rightValue + r) }
+          )
+        }
       }
 
       res shouldBe expected

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/NullableTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/NullableTest.kt
@@ -1,0 +1,185 @@
+package app.cash.quiver.extensions
+
+import arrow.core.Nullable
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+
+class NullableTest : StringSpec({
+  "map2 only performs action when all arguments are not null" {
+    checkAll(
+      Arb.string().orNull(),
+      Arb.string().orNull()
+    ) { a: String?, b: String? ->
+      if (a == null || b == null) Nullable.zip(a, b) { _, _ -> Unit } shouldBe null
+      else Nullable.zip(a, b) { aa, bb -> aa + bb } shouldBe a + b
+    }
+  }
+
+  "map3 only performs action when all arguments are not null" {
+    checkAll(
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull()
+    ) { a: String?, b: String?, c: String? ->
+      if (a == null || b == null || c == null) Nullable.zip(a, b, c) { aa, bb, cc -> aa + bb + cc } shouldBe null
+      else Nullable.zip(a, b, c) { aa, bb, cc -> aa + bb + cc } shouldBe a + b + c
+    }
+  }
+
+  "map4 only performs action when all arguments are not null" {
+    checkAll(
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+    ) { a: String?, b: String?, c: String?, d: String? ->
+      if (a == null || b == null || c == null || d == null) Nullable.zip(
+        a,
+        b,
+        c,
+        d
+      ) { aa, bb, cc, dd -> aa + bb + cc + dd } shouldBe null
+      else Nullable.zip(a, b, c, d) { aa, bb, cc, dd -> aa + bb + cc + dd } shouldBe a + b + c + d
+    }
+  }
+
+  "map5 only performs action when all arguments are not null" {
+    checkAll(
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+    ) { a: String?, b: String?, c: String?, d: String?, e: String? ->
+      if (a == null || b == null || c == null || d == null || e == null) Nullable.zip(
+        a,
+        b,
+        c,
+        d,
+        e
+      ) { _, _, _, _, _ -> Unit } shouldBe null
+      else Nullable.zip(a, b, c, d, e) { aa, bb, cc, dd, ee -> aa + bb + cc + dd + ee } shouldBe a + b + c + d + e
+    }
+  }
+
+  "map6 only performs action when all arguments are not null" {
+    checkAll(
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+    ) { a: String?, b: String?, c: String?, d: String?, e: String?, f: String? ->
+      if (a == null || b == null || c == null || d == null || e == null || f == null) Nullable.zip(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f
+      ) { _, _, _, _, _, _ -> Unit } shouldBe null
+      else Nullable.zip(a, b, c, d, e, f) { aa, bb, cc, dd, ee, ff -> aa + bb + cc + dd + ee + ff } shouldBe a + b + c + d + e + f
+    }
+  }
+
+  "map7 only performs action when all arguments are not null" {
+    checkAll(
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+    ) { a: String?, b: String?, c: String?, d: String?, e: String?, f: String?, g: String? ->
+      if (a == null || b == null || c == null || d == null || e == null || f == null || g == null) Nullable.zip(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g
+      ) { _, _, _, _, _, _, _ -> Unit } shouldBe null
+      else Nullable.zip(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g
+      ) { aa, bb, cc, dd, ee, ff, gg -> aa + bb + cc + dd + ee + ff + gg } shouldBe a + b + c + d + e + f + g
+    }
+  }
+
+  "map8 only performs action when all arguments are not null" {
+    checkAll(
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+      Arb.string().orNull(),
+    ) { a: String?, b: String?, c: String?, d: String?, e: String?, f: String?, g: String?, h: String? ->
+      if (a == null || b == null || c == null || d == null || e == null || f == null || g == null || h == null) Nullable.zip(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h
+      ) { _, _, _, _, _, _, _, _ -> Unit } shouldBe null
+      else Nullable.zip(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h
+      ) { aa, bb, cc, dd, ee, ff, gg, hh -> aa + bb + cc + dd + ee + ff + gg + hh } shouldBe a + b + c + d + e + f + g + h
+    }
+  }
+
+  "map9 only performs action when all arguments are not null" {
+    checkAll(
+      Arb.int().orNull(),
+      Arb.int().orNull(),
+      Arb.int().orNull(),
+      Arb.int().orNull(),
+      Arb.int().orNull(),
+      Arb.int().orNull(),
+      Arb.int().orNull(),
+      Arb.int().orNull(),
+      Arb.int().orNull()
+    ) { a: Int?, b: Int?, c: Int?, d: Int?, e: Int?, f: Int?, g: Int?, h: Int?, i: Int? ->
+      if (a == null || b == null || c == null || d == null || e == null || f == null || g == null || h == null || i == null) {
+        Nullable.zip(a, b, c, d, e, f, g, h, i) { _, _, _, _, _, _, _, _, _ -> Unit } shouldBe null
+      } else {
+        Nullable.zip(
+          a,
+          b,
+          c,
+          d,
+          e,
+          f,
+          g,
+          h,
+          i
+        ) { aa, bb, cc, dd, ee, ff, gg, hh, ii -> aa + bb + cc + dd + ee + ff + gg + hh + ii } shouldBe a + b + c + d + e + f + g + h + i
+      }
+    }
+  }
+})

--- a/testing-lib/api/testing-lib.api
+++ b/testing-lib/api/testing-lib.api
@@ -1,4 +1,5 @@
 public final class app/cash/quiver/arb/ArbitraryKt {
+	public static final fun ior (Lio/kotest/property/Arb$Companion;Lio/kotest/property/Arb;Lio/kotest/property/Arb;)Lio/kotest/property/Arb;
 	public static final fun outcome (Lio/kotest/property/Arb$Companion;Lio/kotest/property/Arb;Lio/kotest/property/Arb;)Lio/kotest/property/Arb;
 }
 

--- a/testing-lib/src/main/kotlin/app/cash/quiver/arb/Arbitrary.kt
+++ b/testing-lib/src/main/kotlin/app/cash/quiver/arb/Arbitrary.kt
@@ -2,10 +2,22 @@ package app.cash.quiver.arb
 
 import app.cash.quiver.Outcome
 import app.cash.quiver.toOutcome
+import arrow.core.Ior
+import arrow.core.leftIor
+import arrow.core.rightIor
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arrow.core.either
 import io.kotest.property.arrow.core.option
 
 fun <E, A> Arb.Companion.outcome(error: Arb<E>, value: Arb<A>): Arb<Outcome<E, A>> =
   Arb.either(error, Arb.option(value)).map { it.toOutcome() }
+
+fun <E, A> Arb.Companion.ior(error: Arb<E>, value: Arb<A>): Arb<Ior<E, A>> =
+  Arb.choice(
+    error.map { it.leftIor() },
+    value.map { it.rightIor() },
+    Arb.bind(error, value) { e, a -> Ior.Both(e, a) }
+  )


### PR DESCRIPTION
This PR adds `zip` for `Nullable`, `Either` & `Ior`. It has currently omitted the `zip` method for `Option`, because it suffers from the same `@Suppress("EXTENSION_SHADOWED_BY_MEMBER")` issue as described in https://github.com/cashapp/quiver/pull/32.

We can of course also add it ahead of time, and we can also provide OpenRewrite recipes for automatically migrating from Arrow to Quiver.