### PR TITLE
Adds Result.toEither()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Change Log
 Next Release
 ----------------------------
 
+**New**
+* Add `kotlin.Result.toEither()` <Jem Mawson>
+
+
 Version 0.2.0 *(2023-04-06)*
 ----------------------------
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 arrow = "1.2.0-RC"
-junit = "5.9.2"
-kotest = "5.5.5"
-kotestArrow = "1.3.0"
+junit = "5.9.3"
+kotest = "5.6.2"
+kotestArrow = "1.3.3"
 # @pin
 kotlin = "1.7.22"
-kotlinBinaryCompatibilityPlugin = "0.13.0"
-mavenPublishGradlePlugin = "0.24.0"
-versionCatalogUpdateGradlePlugin = "0.7.0"
+kotlinBinaryCompatibilityPlugin = "0.13.1"
+mavenPublishGradlePlugin = "0.25.2"
+versionCatalogUpdateGradlePlugin = "0.8.0"
 versionsGradlePlugin = "0.46.0"
 
 [libraries]

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -238,6 +238,10 @@ public final class app/cash/quiver/extensions/OptionKt {
 	public static final fun unit (Larrow/core/Option;)Larrow/core/Option;
 }
 
+public final class app/cash/quiver/extensions/ResultKt {
+	public static final fun toEither (Ljava/lang/Object;)Larrow/core/Either;
+}
+
 public final class app/cash/quiver/extensions/SuspendedFunctionKt {
 	public static final fun map (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public static final fun map (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function2;

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Result.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Result.kt
@@ -1,0 +1,8 @@
+package app.cash.quiver.extensions
+
+import arrow.core.Either
+
+/**
+ * Transforms a `Result<T>` into an `ErrorOr<T>`
+ */
+fun <T> Result<T>.toEither(): ErrorOr<T> = this.map { Either.Right(it) }.getOrElse { Either.Left(it) }

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/ResultTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/ResultTest.kt
@@ -1,0 +1,25 @@
+package app.cash.quiver.extensions
+
+import io.kotest.assertions.arrow.core.shouldBeLeft
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+
+class ResultTest : StringSpec({
+
+  "Can transform any success kotlin.Result into a success ErrorOr" {
+    checkAll(Arb.string()) {
+      Result.success(it).toEither() shouldBeRight it
+    }
+  }
+
+  "Can transform any failure kotlin.Result into a failure ErrorOr" {
+    checkAll(Arb.string().map { Throwable(it) }) {
+      Result.failure<Throwable>(it).toEither() shouldBeLeft it
+    }
+  }
+
+})


### PR DESCRIPTION
Result is a kotlin native type that is similar to ErrorOr<T>
This PR introduces Result.toEither() as a shortcut for transforming Results into Arrowland.
