### PR TITLE
Adds GitHub link to navigation header

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -41,6 +41,7 @@ tasks.withType<DokkaTask>().configureEach {
   dependsOn("copyDocumentationImages")
   pluginConfiguration<org.jetbrains.dokka.base.DokkaBase, DokkaBaseConfiguration> {
     customStyleSheets = listOf(file("custom-styles.css"))
+    templatesDir = file("dokka/templates")
   }
 
   dokkaSourceSets {

--- a/lib/dokka/templates/includes/header.ftl
+++ b/lib/dokka/templates/includes/header.ftl
@@ -1,0 +1,25 @@
+<#import "source_set_selector.ftl" as source_set_selector>
+<#macro display>
+  <div class="navigation-wrapper" id="navigation-wrapper">
+    <div id="leftToggler"><span class="icon-toggler"></span></div>
+    <div class="library-name">
+        <@template_cmd name="pathToRoot">
+          <a href="${pathToRoot}index.html">
+              <@template_cmd name="projectName">
+                <span>${projectName}</span>
+              </@template_cmd>
+          </a>
+        </@template_cmd>
+    </div>
+    <div>
+        <#-- This can be handled by the versioning plugin -->
+        <@version/>
+    </div>
+    <div class="pull-right d-flex">
+      <div style="align-self:center;margin-right:12px;"><a href="https://github.com/cashapp/quiver">GitHub</a></div>
+      <@source_set_selector.display/>
+      <button id="theme-toggle-button"><span id="theme-toggle"></span></button>
+      <div id="searchBar"></div>
+    </div>
+  </div>
+</#macro>


### PR DESCRIPTION
Adds a link to https://github.com/cashapp/quiver in the navigation bar, next to the search input.

This makes it possible to navigate to GitHub from any page.

| Before | After |
| ------------- | ------------- |
|<img width="640" alt="image" src="https://github.com/cashapp/quiver/assets/1646536/8df790da-aa0b-49bb-8954-a5e42a3d4834">|<img width="639" alt="image" src="https://github.com/cashapp/quiver/assets/1646536/52447e3f-3af4-4265-8a94-d5da9737b6ab">|

Based on [Dokka documentation](https://kotlin.github.io/dokka/1.8.0-SNAPSHOT/user_guide/output-formats/html/#custom-html-pages).