### PR TITLE
Make Option's  function lazy, deprecate the eager version

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -239,7 +239,7 @@ public final class app/cash/quiver/extensions/Nullable {
 public final class app/cash/quiver/extensions/OptionKt {
 	public static final fun forEach (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)V
 	public static final fun ifAbsent (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)V
-	public static final fun or (Larrow/core/Option;Larrow/core/Option;)Larrow/core/Option;
+	public static final fun or (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Larrow/core/Option;
 	public static final fun orEmpty (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 	public static final fun toValidatedNel (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Larrow/core/Validated;
 	public static final fun unit (Larrow/core/Option;)Larrow/core/Option;

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -239,6 +239,7 @@ public final class app/cash/quiver/extensions/Nullable {
 public final class app/cash/quiver/extensions/OptionKt {
 	public static final fun forEach (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)V
 	public static final fun ifAbsent (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)V
+	public static final fun or (Larrow/core/Option;Larrow/core/Option;)Larrow/core/Option;
 	public static final fun or (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Larrow/core/Option;
 	public static final fun orEmpty (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 	public static final fun toValidatedNel (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Larrow/core/Validated;

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
@@ -44,6 +44,18 @@ infix fun <T> Option<T>.or(other: () -> Option<T>): Option<T> = when (this) {
 }
 
 /**
+ * Returns `this` if it's a Some, otherwise returns the `other` instance
+ */
+@Deprecated(
+  "Use or(other: () -> Option<T>) instead",
+  ReplaceWith("or(other)")
+)
+infix fun <T> Option<T>.or(other:  Option<T>): Option<T> = when (this) {
+  is Some -> this
+  is None -> other
+}
+
+/**
  * Will return an empty string if the Optional value supplied is None
  */
 fun <T> Option<T>.orEmpty(f: (T) -> String): String = this.map(f).getOrElse { "" }

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
@@ -48,7 +48,7 @@ infix fun <T> Option<T>.or(other: () -> Option<T>): Option<T> = when (this) {
  */
 @Deprecated(
   "Use or(other: () -> Option<T>) instead",
-  ReplaceWith("or(other)")
+  ReplaceWith("or { other }")
 )
 infix fun <T> Option<T>.or(other:  Option<T>): Option<T> = when (this) {
   is Some -> this

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
@@ -38,9 +38,9 @@ fun <A> Option<A>.unit() = map { }
 /**
  * Returns `this` if it's a Some, otherwise returns the `other` instance
  */
-infix fun <T> Option<T>.or(other: Option<T>): Option<T> = when (this) {
+infix fun <T> Option<T>.or(other: () -> Option<T>): Option<T> = when (this) {
   is Some -> this
-  is None -> other
+  is None -> other()
 }
 
 /**

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
@@ -21,7 +21,7 @@ class OptionTest : StringSpec({
   }
 
   "or on Some returns the subject" {
-    "orange".some().or{"apple".some()} shouldBe "orange".some()
+    "orange".some().or { "apple".some() } shouldBe "orange".some()
   }
 
   "or on None returns the supplied value" {

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
@@ -21,12 +21,12 @@ class OptionTest : StringSpec({
   }
 
   "or on Some returns the subject" {
-    "orange".some().or("apple".some()) shouldBe "orange".some()
+    "orange".some().or{"apple".some()} shouldBe "orange".some()
   }
 
   "or on None returns the supplied value" {
     checkAll(Arb.option(Arb.string())) { other ->
-      None.or(other) shouldBe other
+      None.or { other } shouldBe other
     }
   }
 


### PR DESCRIPTION
This change brings `Option` in line with `Either`'s version see: https://github.com/cashapp/quiver/blob/9862a2af9c6000e12d07bf8fb8d158a21ebd9aa7/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt#L34

It would be expected behaviour to not have all the alternatives for the `or` to execute until it is actually needed, especially if there is an expensive side-effect involved.