### PR TITLE
backport Arrow deprecated traverse functions

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -205,11 +205,17 @@ public final class app/cash/quiver/extensions/IorKt {
 	public static final fun zip (Larrow/core/Ior;Lkotlin/jvm/functions/Function2;Larrow/core/Ior;Lkotlin/jvm/functions/Function2;)Larrow/core/Ior;
 }
 
+public final class app/cash/quiver/extensions/IterableKt {
+	public static final fun traverse (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun traverse (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun traverseEither (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun traverseOption (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+}
+
 public final class app/cash/quiver/extensions/ListKt {
 	public static final fun filterNotNone (Ljava/util/List;)Ljava/util/List;
 	public static final fun listOfSome ([Larrow/core/Option;)Ljava/util/List;
 	public static final fun mapNotNone (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
-	public static final fun traverse (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 }
 
 public final class app/cash/quiver/extensions/MapKt {

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -176,6 +176,7 @@ public final class app/cash/quiver/extensions/EitherKt {
 	public static final fun toEither (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Larrow/core/Either;
 	public static final fun traverse (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 	public static final fun traverse (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static final fun traverseOption (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 	public static final fun unit (Larrow/core/Either;)Larrow/core/Either;
 	public static final fun validateNotNull (Ljava/lang/Object;Larrow/core/Option;)Larrow/core/Either;
 	public static synthetic fun validateNotNull$default (Ljava/lang/Object;Larrow/core/Option;ILjava/lang/Object;)Larrow/core/Either;

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -250,6 +250,8 @@ public final class app/cash/quiver/extensions/OptionKt {
 	public static final fun or (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Larrow/core/Option;
 	public static final fun orEmpty (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 	public static final fun toValidatedNel (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Larrow/core/Validated;
+	public static final fun traverse (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun traverseEither (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun unit (Larrow/core/Option;)Larrow/core/Option;
 }
 

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -251,6 +251,7 @@ public final class app/cash/quiver/extensions/OptionKt {
 	public static final fun orEmpty (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 	public static final fun toValidatedNel (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Larrow/core/Validated;
 	public static final fun traverse (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun traverse (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public static final fun traverseEither (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun unit (Larrow/core/Option;)Larrow/core/Option;
 }

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Either.kt
@@ -279,4 +279,11 @@ inline fun <E, A, B> Either<E, A>.traverse(transform: (value: A) -> Option<B>): 
     is Either.Right -> transform(value).map { it.right() }
   }
 
+/**
+ * Synonym for traverse((A)-> Option<B>): Option<Either<E, B>>
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <E, A, B> Either<E, A>.traverseOption(transform: (A) -> Option<B>): Option<Either<E, B>> =
+  quiverTraverse(transform)
+
 fun <E, A> Either<E, Option<A>>.sequence(): Option<Either<E, A>> = quiverTraverse(::identity)

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Iterable.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Iterable.kt
@@ -1,0 +1,46 @@
+package app.cash.quiver.extensions
+
+import arrow.core.Either
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.raise.either
+import kotlin.experimental.ExperimentalTypeInference
+
+/**
+ * Returns an Either of a list of B results of applying the given transform function
+ * to each element(A) in the original collection.
+ */
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+inline fun <E, A, B> Iterable<A>.traverse(f: (A) -> Either<E, B>): Either<E, List<B>> =
+  let { l -> either { l.map { f(it).bind() } } }
+
+/**
+ * Synonym for traverse((A)-> Either<E, B>): Either<E, List<B>>
+ */
+inline fun <E, A, B> Iterable<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, List<B>> =
+  traverse(f)
+
+/**
+ * Returns an Option of a list of B results of applying the given transform function
+ * to each element(A) in the original collection.
+ */
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+inline fun <A, B> Iterable<A>.traverse(f: (A) -> Option<B>): Option<List<B>> {
+  val result = ArrayList<B>()
+  for (element in this) {
+    val mapped = f(element)
+    if (mapped is Some) result.add(mapped.value)
+    else return None
+  }
+  return Some(result)
+}
+
+/**
+ * Synonym for traverse((A)-> Option<B>): Option<List<B>>
+ */
+inline fun <A, B> Iterable<A>.traverseOption(f: (A) -> Option<B>): Option<List<B>> =
+  traverse(f)
+

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/List.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/List.kt
@@ -21,11 +21,3 @@ fun <A> listOfSome(vararg elements: Option<A>): List<A> = elements.toList().filt
  */
 inline fun <A, B> List<A>.mapNotNone(f: (A) -> Option<B>): List<B> =
   this.flatMap { f(it).fold(::emptyList, ::listOf) }
-
-/**
- * Returns an Either of a list of B results of applying the given transform function
- * to each element(A) in the original collection.
- */
-inline fun <E, A, B> Iterable<A>.traverse(f: (A) -> Either<E, B>): Either<E, List<B>> =
-  let { l -> either { l.map { f(it).bind() } } }
-

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Option.kt
@@ -2,12 +2,14 @@
 
 package app.cash.quiver.extensions
 
+import arrow.core.Either
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
 import arrow.core.ValidatedNel
 import arrow.core.getOrElse
 import arrow.core.nonEmptyListOf
+import app.cash.quiver.extensions.traverse as quiverTraverse
 
 /**
  * Takes a function to run if your Option is None. Returns Unit if your Option is Some.
@@ -60,4 +62,22 @@ infix fun <T> Option<T>.or(other:  Option<T>): Option<T> = when (this) {
  */
 fun <T> Option<T>.orEmpty(f: (T) -> String): String = this.map(f).getOrElse { "" }
 
+/**
+ * Map a function that returns an Either across the Option.
+ *
+ * If the option is a None, return a Right(None).
+ * If the option is a Some, apply f to the value. If f returns a Right, wrap the result in a Some.
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <T, E, U> Option<T>.traverse(f: (T) -> Either<E, U>): Either<E, Option<U>> =
+  when (this) {
+    is Some -> f(value).map { Some(it) }
+    is None -> Either.Right(None)
+  }
 
+/**
+ * Synonym for traverse((T)-> Either<E, U>): Either<E, Option<U>>
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <T, E, U> Option<T>.traverseEither(f: (T) -> Either<E, U>): Either<E, Option<U>> =
+  quiverTraverse(f)

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/EitherTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/EitherTest.kt
@@ -20,6 +20,7 @@ import io.kotest.property.arbitrary.list
 import io.kotest.property.arrow.core.option
 import org.junit.jupiter.api.assertThrows
 import app.cash.quiver.extensions.traverse as quiverTraverse
+import app.cash.quiver.extensions.traverseOption as quiverTraverseOption
 import app.cash.quiver.extensions.sequence as quiverSequence
 
 class EitherTest : StringSpec({
@@ -146,9 +147,19 @@ class EitherTest : StringSpec({
       Either.Right(a).quiverTraverse { option } shouldBe option.map { it.right() }
     }
   }
-  "option of Left when Left" {
+  "traverse should return option of Left when Left" {
     checkAll(Arb.int(), Arb.option(Arb.int())) { a, option ->
       Either.Left(a).quiverTraverse { option } shouldBe Some(Either.Left(a))
+    }
+  }
+  "traverseOption should return transformed option as Right when Right" {
+    checkAll(Arb.int(), Arb.option(Arb.int())) { a, option ->
+      Either.Right(a).quiverTraverseOption { option } shouldBe option.map { it.right() }
+    }
+  }
+  "traverseOption should return Option of Left when Left" {
+    checkAll(Arb.int(), Arb.option(Arb.int())) { a, option ->
+      Either.Left(a).quiverTraverseOption { option } shouldBe Some(Either.Left(a))
     }
   }
   "sequence should return list of Some when all are Some in list" {

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
@@ -1,5 +1,6 @@
 package app.cash.quiver.extensions
 
+import app.cash.quiver.extensions.traverse
 import arrow.core.Either
 import arrow.core.None
 import arrow.core.Some
@@ -57,5 +58,14 @@ class OptionTest : StringSpec({
 
   "traverseEither on a Some returns a Right of a Some of the result of the function" {
     Some(42).quiverTraverseEither { Either.Right("$it") } shouldBe Either.Right(Some("42"))
+  }
+
+  "traverse to iterable of Some returns a list of the mapped value" {
+    Some(42).quiverTraverse { listOf("$it") } shouldBe listOf(Some("42"))
+  }
+
+  @Suppress("UNREACHABLE_CODE")
+  "traverse to iterable of None returns an empty list" {
+    None.quiverTraverse { listOf(it) } shouldBe emptyList()
   }
 })

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/OptionTest.kt
@@ -1,6 +1,9 @@
 package app.cash.quiver.extensions
 
+import arrow.core.Either
 import arrow.core.None
+import arrow.core.Some
+import arrow.core.right
 import arrow.core.some
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -8,6 +11,8 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arrow.core.option
 import io.kotest.property.checkAll
+import app.cash.quiver.extensions.traverse as quiverTraverse
+import app.cash.quiver.extensions.traverseEither as quiverTraverseEither
 
 class OptionTest : StringSpec({
 
@@ -36,5 +41,21 @@ class OptionTest : StringSpec({
 
   "orEmpty returns the string supplied if value is Some" {
     "apples".some().orEmpty { "I wanna eat $it" } shouldBe "I wanna eat apples"
+  }
+
+  "traverse on a Some returns a Right of a Some of the result of the function" {
+    Some(42).quiverTraverse { Either.Right("$it") } shouldBe Either.Right(Some("42"))
+  }
+
+  "traverse on a Some returns a Left of the result of the function" {
+    Some(42).quiverTraverse { Either.Left("$it") } shouldBe Either.Left("42")
+  }
+
+  "traverse on None returns a Right of None" {
+    None.quiverTraverse { "something".right() } shouldBe Either.Right(None)
+  }
+
+  "traverseEither on a Some returns a Right of a Some of the result of the function" {
+    Some(42).quiverTraverseEither { Either.Right("$it") } shouldBe Either.Right(Some("42"))
   }
 })

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/TraverseTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/TraverseTest.kt
@@ -1,9 +1,13 @@
 package app.cash.quiver.extensions
 
 import arrow.core.Either
+import arrow.core.None
+import arrow.core.Some
 import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeSome
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
 class TraverseTest : StringSpec({
   "traverse a list of integers returns a Right of the list of mapped strings" {
@@ -31,5 +35,38 @@ class TraverseTest : StringSpec({
       if (it < 3) Either.Right(it) else Either.Left(it)
     }
     result shouldBeLeft 4
+  }
+
+  "traverseEither a list of integers returns a Right of the list of mapped strings" {
+    val result = listOf(1, 2, 3).traverseEither { Either.Right(it.toString()) }
+    result shouldBeRight listOf("1", "2", "3")
+  }
+
+  "traverse a list of integers returns a Some of the list of mapped strings" {
+    val result = listOf(1, 2, 3).traverse { Some(it.toString()) }
+    result shouldBeSome listOf("1", "2", "3")
+  }
+
+  "traverse a set of integers returns a Some of the list of mapped strings" {
+    val result = setOf(1, 2, 3).traverse { Some(it.toString()) }
+    result shouldBeSome listOf("1", "2", "3")
+  }
+
+  "traverse an empty list returns a Some of an empty list" {
+    val result = emptyList<Int>().traverse { Some(it.toString()) }
+    result shouldBeSome emptyList()
+  }
+
+  "traverse a list of integers returns a None if one of the mapped values is None" {
+    val result = listOf(1, 2, 3).traverse {
+      if (it % 2 == 0) None
+      else Some(it.toString())
+    }
+    result shouldBe None
+  }
+
+  "traverseOption a list of integers returns a Some of the list of mapped strings" {
+    val result = listOf(1, 2, 3).traverseOption { Some(it.toString()) }
+    result shouldBeSome listOf("1", "2", "3")
   }
 })


### PR DESCRIPTION
This back-ports some of the `traverse` methods deprecated in Arrow.

- Either.traverseOption synonym
- Iterable.traverse(f -> Either) and Iterable.traverseEither synonym
- Iterable.traverse(f -> Option) and Iterable.traverseOption synonym
- Option.traverse(f -> Either) and Option.traverseEither synonym
- Option.traverse(f -> Iterable)