### PR TITLE
backport Arrow deprecated traverse functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [Unreleased]
-* Backport traverse functions on Sequence (Andrew Parker)
+* Backport traverse functions on Sequence, Map (Andrew Parker)
 * Backport traverse functions on Either, Iterable and Option (Andrew Parker)
 
 ## [0.5.0] - 2023-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+* Backport traverse functions on Sequence (Andrew Parker)
+* Backport traverse functions on Either, Iterable and Option (Andrew Parker)
 
 ## [0.5.0] - 2023-08-26
 

--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,16 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+------------------------------------------------------------------------
+
+This software includes code from the [Λrrow](https://arrow-kt.io/) library.
+
+Copyright (C) 2017 The Λrrow Authors. Licensed under the Apache License, Version 2.0.
+
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -260,6 +260,13 @@ public final class app/cash/quiver/extensions/ResultKt {
 	public static final fun toEither (Ljava/lang/Object;)Larrow/core/Either;
 }
 
+public final class app/cash/quiver/extensions/SequenceKt {
+	public static final fun traverse (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun traverse (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun traverseEither (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun traverseOption (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+}
+
 public final class app/cash/quiver/extensions/SuspendedFunctionKt {
 	public static final fun map (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public static final fun map (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function2;

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -220,6 +220,10 @@ public final class app/cash/quiver/extensions/ListKt {
 
 public final class app/cash/quiver/extensions/MapKt {
 	public static final fun getOption (Ljava/util/Map;Ljava/lang/Object;)Larrow/core/Option;
+	public static final fun traverse (Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun traverse (Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun traverseEither (Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun traverseOption (Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 }
 
 public final class app/cash/quiver/extensions/NonEmptyListKt {

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Map.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Map.kt
@@ -1,10 +1,65 @@
 package app.cash.quiver.extensions
 
+import arrow.core.Either
+import arrow.core.None
 import arrow.core.Option
+import arrow.core.Some
 import arrow.core.getOrNone
+import arrow.core.right
+import arrow.core.some
+import kotlin.experimental.ExperimentalTypeInference
+import app.cash.quiver.extensions.traverse as quiverTraverse
 
 /**
  * Extension function to get an Option from a nullable object on a map.
  */
 fun <K, A> Map<K, A>.getOption(k: K): Option<A> =
   getOrNone(k)
+
+/**
+ * Map a function that returns an Either over all the values in the Map.
+ * If the function returns a Right, the value is added to the resulting Map.
+ * If the function returns a Left, the result is the Left.
+ */
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+inline fun <K, E, A, B> Map<K, A>.traverse(f: (A) -> Either<E, B>): Either<E, Map<K, B>> {
+  val acc = mutableMapOf<K, B>()
+  forEach { (k, v) ->
+    when (val res = f(v)) {
+      is Either.Right -> acc[k] = res.value
+      is Either.Left -> return@traverse res
+    }
+  }
+  return acc.right()
+}
+
+/**
+ * Synonym for traverse((A)-> Either<E, B>): Either<E, Map<K, B>>
+ */
+inline fun <K, E, A, B> Map<K, A>.traverseEither(f: (A) -> Either<E, B>): Either<E, Map<K, B>> =
+  quiverTraverse(f)
+
+/**
+ * Map a function that returns an Option over all the values in the Map.
+ * If the function returns a Some, the value is added to the resulting Map.
+ * If the function returns a None, the result is None.
+ */
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+inline fun <K, A, B> Map<K, A>.traverse(f: (A) -> Option<B>): Option<Map<K, B>> {
+  val acc = mutableMapOf<K, B>()
+  forEach { (k, v) ->
+    when (val res = f(v)) {
+      is Some -> acc[k] = res.value
+      is None -> return@traverse res
+    }
+  }
+  return acc.some()
+}
+
+/**
+ * Synonym for traverse((A)-> Option<B>): Option<Map<K, B>>
+ */
+inline fun <K, A, B> Map<K, A>.traverseOption(f: (A) -> Option<B>): Option<Map<K, B>> =
+  quiverTraverse(f)

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Sequence.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Sequence.kt
@@ -1,0 +1,67 @@
+@file:Suppress("TYPEALIAS_EXPANSION_DEPRECATION", "DEPRECATION")
+
+package app.cash.quiver.extensions
+
+import arrow.core.Either
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import kotlin.experimental.ExperimentalTypeInference
+import app.cash.quiver.extensions.traverse as quiverTraverse
+
+/**
+ * Map a function that returns an Either across the Sequence.
+ */
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <A, E, B> Sequence<A>.traverse(f: (A) -> Either<E, B>): Either<E, List<B>> {
+  // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when using
+  //  Sequence.plus instead. But we don't convert the sequence to a list beforehand to avoid
+  //  forcing too much of the sequence to be evaluated.
+  val result = mutableListOf<B>()
+  forEach { a ->
+    when (val mapped = f(a)) {
+      is Either.Right -> result.add(mapped.value)
+      is Either.Left -> return@traverse mapped
+    }
+  }
+  return Either.Right(result.toList())
+}
+
+/**
+ * Synonym for traverse((A)-> Either<E, B>): Either<E, List<B>>
+ */
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <A, E, B> Sequence<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, List<B>> =
+  quiverTraverse(f)
+
+/**
+ * Map a function that returns an Option across the Sequence.
+ */
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+inline fun <A, B> Sequence<A>.traverse(f: (A) -> Option<B>): Option<List<B>> {
+  // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when using
+  //  Sequence.plus instead. But we don't convert the sequence to a list beforehand to avoid
+  //  forcing too much of the sequence to be evaluated.
+  val result = mutableListOf<B>()
+  forEach { a ->
+    when (val mapped = f(a)) {
+      is Some -> result.add(mapped.value)
+      is None -> return@traverse None
+    }
+  }
+  return Some(result.toList())
+}
+
+/**
+ * Synonym for traverse((A)-> Option<B>): Option<List<B>>
+ */
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <A, B> Sequence<A>.traverseOption(f: (A) -> Option<B>): Option<List<B>> =
+  quiverTraverse(f)

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/MapTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/MapTest.kt
@@ -1,8 +1,20 @@
 package app.cash.quiver.extensions
 
+import arrow.core.Either
+import arrow.core.None
 import arrow.core.Some
+import arrow.core.left
+import arrow.core.maybe
+import arrow.core.right
+import arrow.core.some
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arrow.core.nonEmptyList
+import io.kotest.property.checkAll
+import app.cash.quiver.extensions.traverse as quiverTraverse
 
 class MapTest : StringSpec({
   "Can retrieve null value key" {
@@ -10,5 +22,125 @@ class MapTest : StringSpec({
       "one" to 1,
       "null" to null
     ).getOption("null") shouldBe Some(null)
+  }
+
+  "traverse Either" {
+    mapOf(
+      "1" to 1,
+      "2" to 2
+    ).quiverTraverse { "$it".right() } shouldBe mapOf(
+      "1" to "1",
+      "2" to "2"
+    ).right()
+  }
+
+  "traverseEither" {
+    mapOf(
+      "1" to 1,
+      "2" to 2
+    ).traverseEither { "$it".right() } shouldBe mapOf(
+      "1" to "1",
+      "2" to "2"
+    ).right()
+  }
+
+  "traverse Either on empty map" {
+    emptyMap<String, Int>().quiverTraverse { "$it".right() } shouldBe emptyMap<String, String>().right()
+  }
+
+  "traverse Either returns a Left if the function returns a Left" {
+    mapOf(
+      "1" to 1,
+      "2" to 2
+    ).quiverTraverse {
+      if (it == 2) "error".left() else "$it".right()
+    } shouldBe "error".left()
+  }
+
+  "traverse Either is stack-safe" {
+    val acc = mutableListOf<Int>()
+    val res = (0..20_000).associateWith { it }.quiverTraverse { v ->
+      acc.add(v)
+      Either.Right(v)
+    }
+    res shouldBe acc.associateWith { it }.right()
+    res shouldBe (0..20_000).associateWith { it }.right()
+  }
+
+  "traverse Either short-circuit" {
+    checkAll(Arb.map(Arb.int(), Arb.int())) { ints ->
+      val acc = mutableListOf<Int>()
+      val evens = ints.quiverTraverse {
+        if (it % 2 == 0) {
+          acc.add(it)
+          Either.Right(it)
+        } else Either.Left(it)
+      }
+      acc shouldBe ints.values.takeWhile { it % 2 == 0 }
+      when (evens) {
+        is Either.Right -> evens.value shouldBe ints
+        is Either.Left -> evens.value shouldBe ints.values.first { it % 2 != 0 }
+      }
+    }
+  }
+
+  "traverse Option" {
+    mapOf(
+      "1" to 1,
+      "2" to 2
+    ).quiverTraverse { "$it".some() } shouldBe mapOf(
+      "1" to "1",
+      "2" to "2"
+    ).some()
+  }
+
+  "traverseOption" {
+    mapOf(
+      "1" to 1,
+      "2" to 2
+    ).traverseOption { "$it".some() } shouldBe mapOf(
+      "1" to "1",
+      "2" to "2"
+    ).some()
+  }
+
+  "traverse Option on empty map" {
+    emptyMap<String, Int>().quiverTraverse { "$it".some() } shouldBe emptyMap<String, String>().some()
+  }
+
+  "traverse Option returns a None if the function returns a None" {
+    mapOf(
+      "1" to 1,
+      "2" to 2
+    ).quiverTraverse {
+      if (it == 2) None else "$it".some()
+    } shouldBe None
+  }
+
+  "traverse Option is stack-safe" {
+    // also verifies result order and execution order (l to r)
+    val acc = mutableListOf<Int>()
+    val res = (0..20_000).associateWith { it }.quiverTraverse { a ->
+      acc.add(a)
+      Some(a)
+    }
+    res shouldBe Some(acc.associateWith { it })
+    res shouldBe Some((0..20_000).associateWith { it })
+  }
+
+  "traverse Option short-circuits" {
+    checkAll(Arb.nonEmptyList(Arb.int())) { ints ->
+      val acc = mutableListOf<Int>()
+      val evens = ints.quiverTraverse {
+        if (it % 2 == 0) {
+          acc.add(it)
+          it.some()
+        } else {
+          None
+        }
+      }
+      acc shouldBe ints.takeWhile { it % 2 == 0 }
+      evens.fold({ Unit }) { it shouldBe ints }
+    }
   }
 })

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/SequenceTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/SequenceTest.kt
@@ -1,0 +1,81 @@
+package app.cash.quiver.extensions
+
+import arrow.core.Either
+import arrow.core.None
+import arrow.core.Some
+import arrow.core.left
+import arrow.core.right
+import arrow.core.some
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import app.cash.quiver.extensions.traverse as quiverTraverse
+
+class SequenceTest : StringSpec({
+
+  "traverse Either on an empty sequence returns an empty list" {
+    emptySequence<Int>().quiverTraverse { Either.Left(RuntimeException()) } shouldBe emptyList<Int>().right()
+  }
+
+  "traverse Either on a sequence returns a Right of the mapped list" {
+    (0..9).asSequence().quiverTraverse { Either.Right(it) } shouldBe (0..9).toList().right()
+  }
+
+  "traverse Either on a sequence returns a Left if the mapped function returns a Left" {
+    val error = RuntimeException("boom")
+    (0..9).asSequence().quiverTraverse {
+      if (it == 5) Either.Left(error) else Either.Right(it)
+    } shouldBe error.left()
+  }
+
+  "traverseEither is a synonym for traverse Either" {
+    emptySequence<Int>().traverseEither { Either.Left(RuntimeException()) } shouldBe emptyList<Int>().right()
+  }
+
+  "traverse for Either stack-safe" {
+    // also verifies result order and execution order (l to r)
+    val acc = mutableListOf<Int>()
+    val res = generateSequence(0) { it + 1 }.quiverTraverse { a ->
+      if (a > 20_000) {
+        Either.Left(Unit)
+      } else {
+        acc.add(a)
+        Either.Right(a)
+      }
+    }
+    acc shouldBe (0..20_000).toList()
+    res shouldBe Either.Left(Unit)
+  }
+
+  "traverse Option on an empty sequence returns an empty list" {
+    emptySequence<Int>().quiverTraverse { None } shouldBe emptyList<Int>().some()
+  }
+
+  "traverse Option on a sequence returns a Some of the mapped list" {
+    (0..9).asSequence().quiverTraverse { Some(it) } shouldBe (0..9).toList().some()
+  }
+
+  "traverse Option on a sequence returns a None if the mapped function returns a None" {
+    (0..9).asSequence().quiverTraverse {
+      if (it == 5) None else Some(it)
+    } shouldBe None
+  }
+
+  "traverseOption is a synonym for traverse Option" {
+    emptySequence<Int>().traverseOption { Some(it) } shouldBe emptyList<Int>().some()
+  }
+
+  "traverse for Option stack-safe" {
+    // also verifies result order and execution order (l to r)
+    val acc = mutableListOf<Int>()
+    val res = generateSequence(0) { it + 1 }.quiverTraverse { a ->
+      if (a > 20_000) {
+        None
+      } else {
+        acc.add(a)
+        Some(a)
+      }
+    }
+    acc shouldBe (0..20_000).toList()
+    res shouldBe None
+  }
+})


### PR DESCRIPTION
This back-ports some of the `traverse` methods deprecated in Arrow.

- Map.traverse(f -> Either) and Map.traverseEither synonym
- Map.traverse(f -> Option) and Map.traverseOption synonym
- Sequence.traverse(f -> Either) and Sequence.traverseEither synonym
- Sequence.traverse(f -> Option) and Sequence.traverseOption synonym

Update CHANGELOG to document changes since last release.

Update License to indicate we have taken some code from Arrow.