### PR TITLE
Add Result.catch function to catch non-fatal exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Change Log
 
+## Unreleased
+
+### Added
+* Adds `Result.catch` to enable the same behaviour as `Either.catch` (Alejandro Metke)
+
 ## [0.5.4] - 2024-05-21
 
 ### Added
 * Adds `T.success()` as a shorthand for creating a success `Result` (Jem Mawson)
 * Adds `<T : Throwable>.failure()` as a shorthand for creating a failure `Result` (Jem Mawson)
 * Adds `T.toResult()` as a shorthand for converting nullable types to `Result<T>` (Alejandro Metke)
-* Ads `Result.mapFailure()` to enable mapping the failure in a result to a different `Throwable` (Alejandro Metke)
+* Adds `Result.mapFailure()` to enable mapping the failure in a result to a different `Throwable` (Alejandro Metke)
 * Backport traverse functions on Either, Iterable and Option (Andrew Parker)
 * Backport traverse functions on Sequence, Map and Ior (Andrew Parker)
 

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -276,6 +276,7 @@ public final class app/cash/quiver/extensions/ResultKt {
 	public static final fun success (Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun toEither (Ljava/lang/Object;)Larrow/core/Either;
 	public static final fun toResult (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun tryCatch (Lkotlin/Result$Companion;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class app/cash/quiver/extensions/SequenceKt {

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Result.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Result.kt
@@ -1,6 +1,8 @@
 package app.cash.quiver.extensions
 
 import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 
 /**
  * Transforms a `Result<T>` into an `ErrorOr<T>`
@@ -35,3 +37,11 @@ inline fun <N : Throwable, T> Result<T>.mapFailure(
     else -> Result.failure(f(exception))
   }
 }
+
+/**
+ * Calls the specified function block and returns its encapsulated result if invocation was successful, catching any
+ * non-fatal exceptions thrown from the block function execution and encapsulating them as failures.
+ */
+@JvmName("tryCatch")
+inline fun <R> Result.Companion.catch(f: () -> R): Result<R> =
+  arrow.core.raise.catch({ success(f()) }) { failure(it) }

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/ResultTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/ResultTest.kt
@@ -2,6 +2,7 @@ package app.cash.quiver.extensions
 
 import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.result.shouldBeFailure
 import io.kotest.matchers.result.shouldBeSuccess
@@ -46,5 +47,17 @@ class ResultTest : StringSpec({
     val finalException = RuntimeException("Unable to map invalid integer")
     Result.failure<Int>(NumberFormatException("Invalid integer")).mapFailure { finalException } shouldBeFailure
       finalException
+  }
+
+  "Result.catch only catches non-fatal exceptions" {
+    Result.catch {
+      throw RuntimeException("Non-fatal kaboom!")
+    }.shouldBeFailure()
+
+    shouldThrow<OutOfMemoryError> {
+      Result.catch {
+        throw OutOfMemoryError("Fatal kaboom!")
+      }
+    }
   }
 })


### PR DESCRIPTION
This will enable the same behaviour as `Either.catch`, i.e., catching only non-fatal exceptions.