### PR TITLE
Adds demand extension function

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -3,11 +3,11 @@ public final class DemandKt {
 	public static final fun demand (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
 }
 
-public final class FieldIsNull : java/lang/Throwable {
+public final class ValueIsNull : java/lang/Throwable {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)LFieldIsNull;
-	public static synthetic fun copy$default (LFieldIsNull;Ljava/lang/String;ILjava/lang/Object;)LFieldIsNull;
+	public final fun copy (Ljava/lang/String;)LValueIsNull;
+	public static synthetic fun copy$default (LValueIsNull;Ljava/lang/String;ILjava/lang/Object;)LValueIsNull;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getMessage ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Demand.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Demand.kt
@@ -3,7 +3,7 @@ import arrow.core.Option
 
 /**
  * Ensures that the nullable receiver is not null. Converts the receiver to a successful [Result]
- * if not null or to a failure containing a [FieldIsNull] exception if null.
+ * if not null or to a failure containing a [ValueIsNull] exception if null.
  *
  * Example:
  * ```kotlin
@@ -13,22 +13,22 @@ import arrow.core.Option
  *
  * // When the receiver is null
  * val foo: String? = null
- * foo.demand("foo") // Result.Failure(FieldIsNull("Field foo is null"))
+ * foo.demand("foo") // Result.Failure(ValueIsNull("Value foo is null"))
  * ```
  *
- * @param field the name of the field being validated. Used to generate a meaningful error message if the field is null.
- * @return a [Result] containing the receiver value if not null, or a failure with a [FieldIsNull] exception if the receiver is null.
+ * @param label the name of the value being validated. Used to generate a meaningful error message if the value is null.
+ * @return a [Result] containing the receiver value if not null, or a failure with a [ValueIsNull] exception if the receiver is null.
  */
-fun <A> A?.demand(field: String): Result<A> =
-  this.toResult { FieldIsNull("Field $field is null") }
+fun <A> A?.demand(label: String): Result<A> =
+  this.toResult { ValueIsNull("Value $label is null") }
 
 /**
  * Ensures an Option is Some, wrapping the inner value in a `Result`.
- * If the Option is empty, the operation will fail, associating the failure with the provided field name.
+ * If the Option is empty, the operation will fail, associating the failure with the provided label name.
  *
- * @param field The name of the field to associate with the failure if the Option is empty.
- * @return A Result containing the value inside the Option if present, or a failure associated with the given field if empty.
+ * @param label The name of the value to associate with the failure if the Option is empty.
+ * @return A Result containing the value inside the Option if present, or a failure associated with the given value if empty.
  */
-fun <A> Option<A>.demand(field: String): Result<A> = this.getOrNull().demand(field)
+fun <A> Option<A>.demand(label: String): Result<A> = this.getOrNull().demand(label)
 
-data class FieldIsNull(override val message: String?) : Throwable(message)
+data class ValueIsNull(override val message: String?) : Throwable(message)

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/DemandTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/DemandTest.kt
@@ -1,6 +1,6 @@
 package app.cash.quiver.extensions;
 
-import FieldIsNull
+import ValueIsNull
 import arrow.core.None
 import arrow.core.Some
 import demand
@@ -20,10 +20,10 @@ class DemandTest : StringSpec({
 
   "demand is Failure when value is null" {
     val foo: String? = null
-    foo.demand("label").shouldBeFailure<FieldIsNull>()
+    foo.demand("label").shouldBeFailure<ValueIsNull>()
   }
 
   "demand is Failure when value is None" {
-    None.demand("label").shouldBeFailure<FieldIsNull>()
+    None.demand("label").shouldBeFailure<ValueIsNull>()
   }
 })


### PR DESCRIPTION
This extension provides a clean and concise mechanism for asserting values are not null while operating within a result computation.

For example, when operating on a request object with many nullable fields:

```kotlin
data class FooRequest(
  val foo: String?,
  val bar: String?,
  val foobar: String?
)

// Given a foo request, we can make sure fields are not null:
result {
  val foo = fooRequest.foo.demand("foo").bind()
  val bar = fooRequest.bar.demand("bar").bind()
  val foobar = fooRequest.foobar.demand("foobar").bind()
}
```