### PR TITLE
Removes mavenPublishing block from testing-lib

### DIFF
--- a/testing-lib/build.gradle.kts
+++ b/testing-lib/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   id("java-library")
   id("org.jetbrains.kotlin.jvm")
-  id("com.vanniktech.maven.publish")
 }
 
 repositories {
@@ -19,10 +18,6 @@ java {
     languageVersion.set(JavaLanguageVersion.of(11))
   }
   withSourcesJar()
-}
-
-mavenPublishing {
-  configure(com.vanniktech.maven.publish.KotlinJvm())
 }
 
 dependencies {


### PR DESCRIPTION
Follow up to #131 and #130.

testing-lib does not need its own publishing block.